### PR TITLE
update to latest cpg flow to avoid bad pypi build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg1
 
 # Dragen align pa pipeline version.
-ENV VERSION=2.0.3
+ENV VERSION=2.0.4
 
 ARG ICA_CLI_VERSION=${ICA_CLI_VERSION:-2.34.0}
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ analysis-runner \
 --config config.toml \
 --output-dir ica-test \
 --description "Description for analysis-runner" \
---image "australia-southeast1-docker.pkg.dev/cpg-common/images-dev/dragen_align_pa:2.0.3-1" \
+--image "australia-southeast1-docker.pkg.dev/cpg-common/images-dev/dragen_align_pa:2.0.4-1" \
 dragen_align_pa
 ```
 Note that the `--output-dir` flag is required by `analysis-runner`, but is not used in this workflow. No outputs are written to the location, so any placeholder value can be entered here.

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -16,7 +16,7 @@ status_reporter = 'metamist'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:2.0.3-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:2.0.4-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 
 dependencies=[
-    'cpg-flow>=v0.2.2',
+    'cpg-flow>=v0.3.1',
     'loguru>=0.7.3'
 ]
 
@@ -33,7 +33,7 @@ Repository = "https://github.com/populationgenomics/dragen_align_pa"
 [project.optional-dependencies]
 # # various requirements when running cpg-flow/analysis-runner
 cpg = [
-    'cpg-flow>=v0.2.2',
+    'cpg-flow>=v0.3.1',
 ]
 test = [
     'bump2version',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description='Realign CRAM files with Dragen 3.7.8 in ICA'
 readme = "README.md"
 # # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="2.0.3"
+version="2.0.4"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -111,7 +111,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "2.0.3"
+current_version = "2.0.4"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false


### PR DESCRIPTION
# Purpose

  - Update to `cpg_flow 0.3.1` as `0.3.0` was broken on pypi and is now removed 

## Proposed Changes

  - Bump `cpg_flow` version to `0.3.1`