### PR TITLE
make analysis storage id a config parameter

### DIFF
--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -51,6 +51,7 @@ reference_tags = ['test_reference_tags']
 
 # The pipeline ID is from ICA and is specific to the exact pipeline being run. This should not need to be changed.
 [ica.pipelines]
+analysis_storage_id = "3fab13dd-46e7-4b54-bb34-b80a01a99379"
 dragen_version = 'dragen_3_7_8'
 # F2 instance CRAM pipeline
 cram = 'cbac3d1f-737f-44f2-9a40-f7f2589b5fad'

--- a/src/dragen_align_pa/jobs/run_intake_qc_pipeline.py
+++ b/src/dragen_align_pa/jobs/run_intake_qc_pipeline.py
@@ -29,6 +29,7 @@ def run_md5_pipeline(
         ),
         outputParentFolderId=md5_outputs_folder_id,
         analysisInput=NextflowAnalysisInput(inputs=[AnalysisDataInput(parameterCode='in', dataIds=ica_fastq_ids)]),
+        analysisStorageId=config_retrieve(['ica', 'pipelines', 'analysis_storage_id']),
     )
 
     path_params: dict[str, str] = {'projectId': project_id}


### PR DESCRIPTION
# Purpose

 Make the storage setting for the md5 pipeline a config parameter, as the current cohort size overwhelms the default storage.