### PR TITLE
feat: Update MD5 pipeline to streaming version and refactor credentia…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.1.0
+ENV VERSION=3.2.0
 
 ARG ICA_CLI_VERSION="2.39.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.0.1
+ENV VERSION=3.1.0
 
 ARG ICA_CLI_VERSION="2.39.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.0.1
+## Pipeline Overview v3.1.0
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.1.0
+## Pipeline Overview v3.2.0
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -28,7 +28,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.0.1-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.1.0-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -72,6 +72,10 @@ dragen_ht_id = 'fil.854d49a151a24edae5d708da2935b1b0'
 #md5sum pipeline
 md5_pipeline_id = "cbc8cf45-851f-49a8-bd50-3c66d205ab97"
 
+# Chunk size for the new streaming MD5 pipeline
+[ica.pipelines.md5]
+chunk_size = "100"
+
 # IDs for all CRAM references that were previously used to generate the CRAM files that are to be realigned
 [ica.cram_references]
 

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -70,7 +70,7 @@ fastq = '393e2423-3c0d-42f2-aa83-910a48a9c32c'
 dragen_ht_id = 'fil.854d49a151a24edae5d708da2935b1b0'
 
 #md5sum pipeline
-md5_pipeline_id = "cbc8cf45-851f-49a8-bd50-3c66d205ab97"
+md5_pipeline_id = "e767f290-bc60-4281-b11d-6a65c9791253"
 
 # Chunk size for the new streaming MD5 pipeline
 [ica.pipelines.md5]

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -28,7 +28,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.1.0-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.2.0-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/src/dragen_align_pa/jobs/manage_dragen_mlr.py
+++ b/src/dragen_align_pa/jobs/manage_dragen_mlr.py
@@ -15,16 +15,6 @@ from dragen_align_pa.constants import BUCKET_NAME
 from dragen_align_pa.jobs.ica_pipeline_manager import manage_ica_pipeline_loop
 
 
-def _authenticate() -> None:
-    """Authenticates the ICA CLI."""
-    # shell=True is required for the multi-line ICA_CLI_SETUP script
-    utils.run_subprocess_with_log(  # noqa: S604
-        ica_cli_utils.ICA_CLI_SETUP,
-        'Authenticate ICA CLI',
-        shell=True,
-    )
-
-
 def _mlr_enter_project(mlr_project: str) -> None:
     """Enters the specified MLR project."""
     # Set ICA project context
@@ -154,7 +144,7 @@ def _submit_mlr_run(
 
     try:
         # --- 0. Authenticate ---
-        _authenticate()
+        ica_cli_utils.authenticate_ica_cli()
 
         # --- 1. Find input file paths ---
         cram_url, gvcf_url = _mlr_find_input_urls(ica_base_folder, sg_name)

--- a/src/dragen_align_pa/jobs/manage_md5_pipeline.py
+++ b/src/dragen_align_pa/jobs/manage_md5_pipeline.py
@@ -9,7 +9,7 @@ from cpg_utils.config import config_retrieve, try_get_ar_guid
 from icasdk.apis.tags import project_analysis_api, project_data_api
 from loguru import logger
 
-from dragen_align_pa import ica_api_utils, ica_utils
+from dragen_align_pa import ica_api_utils, ica_cli_utils, ica_utils
 from dragen_align_pa.constants import BUCKET_NAME
 from dragen_align_pa.jobs import run_intake_qc_pipeline
 from dragen_align_pa.jobs.ica_pipeline_manager import manage_ica_pipeline_loop
@@ -25,7 +25,6 @@ def _get_fastq_ica_id_list(
     Finds ICA file IDs for a list of fastq filenames.
     """
     fastq_ids: list[str] = []
-    fastq_ids_and_filenames: list[str] = []
 
     # Handle potentially large lists by batching API calls
     batch_size = config_retrieve(['ica', 'api', 'batch_size'], default=20)
@@ -40,9 +39,7 @@ def _get_fastq_ica_id_list(
         )  # type: ignore[no-untyped-call]
         for item in api_response.body['items']:  # pyright: ignore[reportUnknownArgumentType]
             file_id = item['data']['id']  # pyright: ignore[reportUnknownVariableType]
-            file_name = item['data']['details']['name']  # pyright: ignore[reportUnknownVariableType]
             fastq_ids.append(file_id)  # type: ignore[arg-type]
-            fastq_ids_and_filenames.append(f'{file_id}\t{file_name}')
 
     if len(fastq_ids) != len(fastq_filenames):
         logger.warning(
@@ -53,7 +50,7 @@ def _get_fastq_ica_id_list(
         # For now, we'll just log and continue with the files we found.
 
     with fastq_ids_outpath.open('w') as fq_outpath:
-        fq_outpath.write('\n'.join(fastq_ids_and_filenames))
+        fq_outpath.write('\n'.join(fastq_ids))
 
     logger.info(f'Found {len(fastq_ids)} total FASTQ file IDs.')
     return fastq_ids
@@ -82,8 +79,7 @@ def _create_md5_output_folder(
 
 def _submit_md5_run(
     cohort_name: str,
-    ica_fastq_ids: list[str],
-    project_id: str,
+    fastq_list_file_id: str,
     ar_guid: str,
     md5_outputs_folder_id: str,
 ) -> str:
@@ -96,9 +92,8 @@ def _submit_md5_run(
         api_instance = project_analysis_api.ProjectAnalysisApi(api_client)
         md5_pipeline_id: str = run_intake_qc_pipeline.run_md5_pipeline(
             cohort_name=cohort_name,
-            ica_fastq_ids=ica_fastq_ids,
+            fastq_list_file_id=fastq_list_file_id,
             api_instance=api_instance,
-            project_id=project_id,
             ar_guid=ar_guid,
             md5_outputs_folder_id=md5_outputs_folder_id,
         )
@@ -129,6 +124,9 @@ def run(
     project_id: str = secrets['projectID']
 
     path_parameters: dict[str, str] = {'projectId': project_id}
+    ar_guid: str = try_get_ar_guid()
+    fastq_list_file_id: str
+    md5_outputs_folder_id: str
 
     with ica_api_utils.get_ica_api_client() as api_client:
         api_instance = project_data_api.ProjectDataApi(api_client)
@@ -145,22 +143,42 @@ def run(
             logger.error('No FASTQ file IDs found in ICA. Cannot start MD5 pipeline.')
             raise ValueError('No FASTQ file IDs found in ICA.')
 
-        folder_path: str = f'/{BUCKET_NAME}/{config_retrieve(["ica", "data_prep", "output_folder"])}'
+        # Upload the FASTQ ID list to ICA
+        fastq_list_folder = (
+            f'/{BUCKET_NAME}/{config_retrieve(["ica", "data_prep", "output_folder"])}/{cohort_name}/fastq_lists'
+        )
+        fastq_list_filename = f'{cohort_name}_{ar_guid}_fastq_ids.txt'
 
-        md5_outputs_folder_id: str = _create_md5_output_folder(
+        ica_cli_utils.authenticate_ica_cli()
+        ica_cli_utils.upload_local_file(
+            local_file_path=str(outputs['fastq_ids_outpath']),
+            ica_folder_path=fastq_list_folder,
+        )
+
+        # Find the uploaded file to get its ID
+        fastq_list_file_details = ica_api_utils.get_file_details_from_ica(
+            api_instance=api_instance,
+            path_params=path_parameters,
+            ica_folder_path=fastq_list_folder,
+            file_name=fastq_list_filename,
+        )
+        if not fastq_list_file_details:
+            raise FileNotFoundError(f'Could not find uploaded fastq list file in ICA: {fastq_list_folder}')
+        fastq_list_file_id = fastq_list_file_details['id']
+
+        # Create output folder
+        folder_path: str = f'/{BUCKET_NAME}/{config_retrieve(["ica", "data_prep", "output_folder"])}'
+        md5_outputs_folder_id = _create_md5_output_folder(
             folder_path=folder_path,
             api_instance=api_instance,
             cohort_name=cohort_name,
             path_parameters=path_parameters,
         )
 
-    ar_guid: str = try_get_ar_guid()
-
     submit_callable = partial(
         _submit_md5_run,
         cohort_name=cohort_name,
-        ica_fastq_ids=ica_fastq_ids,
-        project_id=project_id,
+        fastq_list_file_id=fastq_list_file_id,
         ar_guid=ar_guid,
         md5_outputs_folder_id=md5_outputs_folder_id,
     )

--- a/src/dragen_align_pa/jobs/run_intake_qc_pipeline.py
+++ b/src/dragen_align_pa/jobs/run_intake_qc_pipeline.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Any, Literal
 
 from cpg_utils.config import config_retrieve
 from icasdk.apis.tags import project_analysis_api
 from icasdk.model.analysis_data_input import AnalysisDataInput
+from icasdk.model.analysis_parameter_input import AnalysisParameterInput
 from icasdk.model.analysis_tag import AnalysisTag
 from icasdk.model.create_nextflow_analysis import CreateNextflowAnalysis
 from icasdk.model.nextflow_analysis_input import NextflowAnalysisInput
@@ -12,13 +13,17 @@ from dragen_align_pa import ica_api_utils
 
 def run_md5_pipeline(
     cohort_name: str,
-    ica_fastq_ids: list[str],
+    fastq_list_file_id: str,
     api_instance: project_analysis_api.ProjectAnalysisApi,
-    project_id: str,
     ar_guid: str,
     md5_outputs_folder_id: str,
 ) -> str:
     header_params: dict[Any, Any] = {}
+    chunk_size = config_retrieve(['ica', 'pipelines', 'md5', 'chunk_size'], default='100')
+    secrets: dict[Literal['projectID', 'apiKey'], str] = ica_api_utils.get_ica_secrets()
+    project_id: str = secrets['projectID']
+    api_key: str = secrets['apiKey']
+
     body = CreateNextflowAnalysis(
         userReference=f'{cohort_name}_{ar_guid}',
         pipelineId=config_retrieve(['ica', 'pipelines', 'md5_pipeline_id']),
@@ -28,7 +33,14 @@ def run_md5_pipeline(
             referenceTags=config_retrieve(['ica', 'tags', 'reference_tags']),
         ),
         outputParentFolderId=md5_outputs_folder_id,
-        analysisInput=NextflowAnalysisInput(inputs=[AnalysisDataInput(parameterCode='in', dataIds=ica_fastq_ids)]),
+        analysisInput=NextflowAnalysisInput(
+            inputs=[
+                AnalysisDataInput(parameterCode='in', dataIds=[fastq_list_file_id]),
+                AnalysisParameterInput(parameterCode='ica_project_id', values=[project_id]),
+                AnalysisParameterInput(parameterCode='ica_api_key', values=[api_key]),
+                AnalysisParameterInput(parameterCode='chunk_size', values=[chunk_size]),
+            ],
+        ),
         analysisStorageId=config_retrieve(['ica', 'pipelines', 'analysis_storage_id']),
     )
 


### PR DESCRIPTION
…l handling

This commit introduces significant updates to the MD5 pipeline within dragen_align_pa to support a new streaming-based approach.

Key changes include:
- Refactored  to extract common authentication and file upload logic into reusable functions (, ).
- Updated  to orchestrate the new MD5 pipeline:
    - Modified  to output ICA file IDs only.
    - Implemented logic to upload the FASTQ ID list to ICA using the new CLI utilities.
    - Adjusted  and its calling context to pass the uploaded file ID.
- Modified  to construct the ICA pipeline submission request with the new streaming parameters (, , ) and to accept the uploaded FASTQ ID list file.
- Enhanced security by refactoring credential handling:  and  are now retrieved from the secrets manager exactly where they are needed (within ), rather than being passed as arguments through function calls.
- Reverted unintended changes to  to restore its original functionality and ensure proper operation of the MLR pipeline.
- Added  configuration parameter to .
