### PR TITLE
Update GVCF blocking strategy and bump to v3.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.134.cpg1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.2.0
+ENV VERSION=3.2.1
 
 ARG ICA_CLI_VERSION="2.39.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.2.0
+## Pipeline Overview v3.2.1
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -28,7 +28,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.2.0-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.2.1-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "2.1.0"
+current_version = "3.2.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false

--- a/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
+++ b/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
@@ -98,7 +98,7 @@ def _prepare_fastq_inputs(
             value=(
                 '--qc-coverage-reports-1 cov_report,cov_report '
                 "--qc-coverage-filters-1 'mapq<1,bq<0,mapq<1,bq<0' "
-                "'--vc-gvcf-gq-bands 13 20 30 40 '"
+                "'--vc-gvcf-gq-bands 10 20 30 40 '"
             ),
         ),
     ]
@@ -155,7 +155,7 @@ def _build_cram_specific_inputs(
                     '--qc-coverage-count-soft-clipped-bases true '
                     '--qc-coverage-reports-1 cov_report,cov_report '
                     "--qc-coverage-filters-1 'mapq<1,bq<0,mapq<1,bq<0' "
-                    '--vc-gvcf-gq-bands 13 20 30 40 '
+                    '--vc-gvcf-gq-bands 10 20 30 40 '
                 ),
             ),
         ]

--- a/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
+++ b/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
@@ -98,7 +98,7 @@ def _prepare_fastq_inputs(
             value=(
                 '--qc-coverage-reports-1 cov_report,cov_report '
                 "--qc-coverage-filters-1 'mapq<1,bq<0,mapq<1,bq<0' "
-                "'--vc-gvcf-gq-bands 10 20 30 40 '"
+                '--vc-gvcf-gq-bands 10 20 30 40 '
             ),
         ),
     ]


### PR DESCRIPTION
## Summary
- Update GVCF blocking lower bound from 13 to 10
- Bump version from 3.2.0 to 3.2.1

## Test plan
- [ ] Verify GVCF blocking parameter change produces expected output
- [ ] Confirm version is 3.2.1 across Dockerfile, README, config, and pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)