### PR TITLE
Fix mlr gvcf header

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@
 
 #     - uses: actions/setup-python@v4
 #       with:
-#         python-version: '3.10'
+#         python-version: '3.11'
 #         cache: 'pip'
 #         cache-dependency-path: pyproject.toml
 

--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ cython_debug/
 # local
 local_test/
 prod_runs/
+reference_data/
 
 # Mac
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,10 @@ build-backend = "hatchling.build"
 name='dragen_align_pa'
 description='Realign CRAM files with Dragen 3.7.8 in ICA'
 readme = "README.md"
-# # currently cpg-flow is pinned to this version
+# # currently cpg-flow is pinned to this version.
+# # Keep [tool.ruff] target-version and [tool.mypy] python_version in sync with this.
 requires-python = ">=3.11,<3.12"
-version="2.1.0"
+version="3.2.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -68,6 +69,7 @@ exclude = '''
 '''
 
 [tool.mypy]
+python_version = "3.11"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
@@ -75,6 +77,7 @@ testpaths = ['test']
 
 [tool.ruff]
 line-length = 120
+target-version = "py311"
 extend-exclude = ["venv", ".mypy_cache", ".venv", "build", "dist"]
 
 [tool.ruff.format]

--- a/src/dragen_align_pa/jobs/download_specific_files_from_ica.py
+++ b/src/dragen_align_pa/jobs/download_specific_files_from_ica.py
@@ -12,7 +12,7 @@ from google.cloud.storage.bucket import Bucket
 from icasdk.apis.tags import project_data_api
 from loguru import logger
 
-from dragen_align_pa import ica_api_utils, ica_utils, utils
+from dragen_align_pa import ica_api_utils, ica_utils
 from dragen_align_pa.constants import (
     BUCKET_NAME,
 )
@@ -99,10 +99,15 @@ def run(
     sequencing_group: SequencingGroup,
     file_spec: FileTypeSpec,
     pipeline_id_arguid_path: cpg_utils.Path,
+    gcs_output_dir: cpg_utils.Path,
 ) -> None:
     """
     The main Python function for the download job.
     Coordinates helper functions to list, filter, and stream files.
+
+    `gcs_output_dir` is the directory the calling stage declared in `expected_outputs`
+    (e.g. `outputs['gvcf'].parent`); both bucket and prefix are derived from it so the
+    download lands exactly where the stage promised.
     """
     sg_name: str = sequencing_group.name
     ica_analysis_output_folder: str = config_retrieve(
@@ -123,9 +128,11 @@ def run(
     logger.info(f'Targeting ICA folder: {base_ica_folder_path}')
 
     # --- 3. Setup GCS Client ---
-    gcs_output_path_prefix = str(utils.get_output_path(f'{file_spec.gcs_prefix}')).removeprefix(f'gs://{BUCKET_NAME}/')
+    gcs_output_bucket_name, _, gcs_output_path_prefix = (
+        str(gcs_output_dir).removeprefix('gs://').partition('/')
+    )
     storage_client = storage.Client()
-    gcs_bucket = storage_client.bucket(BUCKET_NAME)
+    gcs_bucket = storage_client.bucket(gcs_output_bucket_name)
 
     secrets: dict[Literal['projectID', 'apiKey'], str] = ica_api_utils.get_ica_secrets()
     path_parameters: dict[str, str] = {'projectId': secrets['projectID']}

--- a/src/dragen_align_pa/jobs/ica_pipeline_manager.py
+++ b/src/dragen_align_pa/jobs/ica_pipeline_manager.py
@@ -128,7 +128,8 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                         if 'ar_guid' in data:
                             preserved_ar_guid_for_target = data['ar_guid']
                             logger.info(
-                                f"Preserved AR GUID '{preserved_ar_guid_for_target}' from existing file for {target.name}."
+                                f"Preserved AR GUID '{preserved_ar_guid_for_target}' from existing file "
+                                f'for {target.name}.'
                             )
                 except (json.JSONDecodeError, KeyError) as e:
                     logger.warning(f"Could not read AR GUID from {pipeline_id_arguid_file}: {e}.")
@@ -150,8 +151,8 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
         for target in monitored_targets:
             if is_finished(target):
                 continue
-            target_name: str = target.name
-            pipeline_id_arguid_file: cpg_utils.Path = outputs[
+            target_name = target.name
+            pipeline_id_arguid_file = outputs[
                 pipeline_id_file_key_template.format(target_name=target_name)
             ]
 
@@ -198,7 +199,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                 elif pipeline_status == 'SUCCEEDED':
                     target.set_status(new_status=PipelineStatus.SUCCEEDED)
                     logger.info(f'{pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}')
-                    pipeline_success_file: cpg_utils.Path = outputs[
+                    pipeline_success_file = outputs[
                         success_file_key_template.format(target_name=target_name)
                     ]
                     with pipeline_success_file.open('w') as success_file:

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -38,14 +38,7 @@ def reheader_mlr_gvcf(
         f"""
         set -euo pipefail
 
-        bcftools view -h {gvcf_input_group['base_gvcf']} > base_header.txt
-        bcftools view -h {gvcf_input_group['recal_gvcf']} > recal_header.txt
-
-
-        awk 'FNR==NR {{ if (/^##GVCFBlock/) blocks = blocks $0 ORS; next }} \\
-        !inserted && /^##INFO=/ {{ printf "%s", blocks; inserted = 1 }} \\
-        {{ print }}' base_header.txt recal_header.txt > new_header.txt \\
-        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
+        bcftools annotate -h <(bcftools view -h {gvcf_input_group['base_gvcf']} | grep '^##GVCFBlock') {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
 
         # Index the reheadered gVCF
         bcftools index -t {reheadered_gvcf_outputs['gvcf.gz']}

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -45,11 +45,9 @@ def reheader_mlr_gvcf(
         awk 'FNR==NR {{ if (/^##GVCFBlock/) blocks = blocks $0 ORS; next }} \\
         !inserted && /^##INFO=/ {{ printf "%s", blocks; inserted = 1 }} \\
         {{ print }}' base_header.txt recal_header.txt > new_header.txt \\
-        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
+        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} --no-version \\
+            --write-index=tbi -o {reheadered_gvcf_outputs['gvcf.gz']}
 
-
-        # Index the reheadered gVCF
-        bcftools index -t {reheadered_gvcf_outputs['gvcf.gz']}
         """
     )
 

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -45,9 +45,10 @@ def reheader_mlr_gvcf(
         awk 'FNR==NR {{ if (/^##GVCFBlock/) blocks = blocks $0 ORS; next }} \\
         !inserted && /^##INFO=/ {{ printf "%s", blocks; inserted = 1 }} \\
         {{ print }}' base_header.txt recal_header.txt > new_header.txt \\
-        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} --no-version \\
-            --write-index=tbi -o {reheadered_gvcf_outputs['gvcf.gz']}
+        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
 
+        # Index the reheadered gVCF
+        bcftools index -t {reheadered_gvcf_outputs['gvcf.gz']}
         """
     )
 

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-import cpg_utils
+from typing import TYPE_CHECKING
+
 from cpg_utils.config import image_path
 from cpg_utils.hail_batch import Batch, get_batch
-from hailtop.batch.job import BashJob
+
+if TYPE_CHECKING:
+    import cpg_utils
+    from hailtop.batch.job import BashJob
 
 
 def reheader_mlr_gvcf(

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -45,7 +45,7 @@ def reheader_mlr_gvcf(
         awk 'FNR==NR {{ if (/^##GVCFBlock/) blocks = blocks $0 ORS; next }} \\
         !inserted && /^##INFO=/ {{ printf "%s", blocks; inserted = 1 }} \\
         {{ print }}' base_header.txt recal_header.txt > new_header.txt \\
-        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']} -Oz
+        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
 
 
         # Index the reheadered gVCF

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -38,10 +38,10 @@ def reheader_mlr_gvcf(
         f"""
         set -euo pipefail
 
-        bcftools annotate -h <(bcftools view -h {gvcf_input_group['base_gvcf']} | grep '^##GVCFBlock') {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
+        bcftools annotate --no-version --write-index=tbi \\
+            -h <(bcftools view -h {gvcf_input_group['base_gvcf']} | grep '^##GVCFBlock') \\
+            {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
 
-        # Index the reheadered gVCF
-        bcftools index -t {reheadered_gvcf_outputs['gvcf.gz']}
         """
     )
 

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import re
+from cpg_utils.hail_batch import Batch, get_batch
+import cpg_utils
+from cpg_utils.config import image_path
+from hailtop.batch.job import BashJob
+
+def reheader_mlr_gvcf(
+    base_gvcf_path: cpg_utils.Path,
+    recal_gvcf_path: cpg_utils.Path,
+    reheadered_gvcf_path: cpg_utils.Path,
+) -> BashJob:
+    """
+    Reheader the MLR gVCF to insert the gvcf ref block information from the original gVCF header.
+    """
+
+    b: Batch = get_batch()
+    job: BashJob = b.new_bash_job(name='reheader_mlr_gvcf')
+    job.image(image_path{'bcftools', '1.23-2'})
+    job.storage(storage='16GB')
+
+    gvcf_input_group = b.read_input_group(
+        base_gvcf=str(base_gvcf_path),
+        recal_gvcf=str(recal_gvcf_path),
+    )
+
+    job.declare_resource_group(
+        reheadered_gvcf={
+            'gvcf.gz': '{root}.gvcf.gz',
+            'gvcf.gz.tbi': '{root}.gvcf.gz.tbi',
+        }
+    )
+
+    reheadered_gvcf_outputs = job.reheadered_gvcf
+
+    job.command(
+        f"""
+        set -euo pipefail
+
+        bcftools view -h {gvcf_input_group['base_gvcf']} > base_header.txt
+        bcftools view -h {gvcf_input_group['recal_gvcf']} > recal_header.txt
+
+
+        awk 'FNR==NR {{ if (/^##GVCFBlock/) blocks = blocks $0 ORS; next }} \\
+        !inserted && /^##INFO=/ {{ printf "%s", blocks; inserted = 1 }} \\
+        {{ print }}' base_header.txt recal_header.txt > new_header.txt \\
+        && bcftools reheader -h new_header.txt {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']} -Oz
+
+
+        # Index the reheadered gVCF
+        bcftools index {reheadered_gvcf_outputs['gvcf.gz']}
+        """
+    )
+
+    b.write_output(reheadered_gvcf_outputs, str(reheadered_gvcf_path).removesuffix('.gvcf.gz'))
+
+    return job

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
-import re
-from cpg_utils.hail_batch import Batch, get_batch
+
 import cpg_utils
 from cpg_utils.config import image_path
+from cpg_utils.hail_batch import Batch, get_batch
 from hailtop.batch.job import BashJob
+
 
 def reheader_mlr_gvcf(
     base_gvcf_path: cpg_utils.Path,
@@ -16,7 +17,7 @@ def reheader_mlr_gvcf(
 
     b: Batch = get_batch()
     job: BashJob = b.new_bash_job(name='reheader_mlr_gvcf')
-    job.image(image_path{'bcftools', '1.23-2'})
+    job.image(image_path('bcftools', '1.23-2'))
     job.storage(storage='16GB')
 
     gvcf_input_group = b.read_input_group(

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -44,7 +44,7 @@ def reheader_mlr_gvcf(
 
         bcftools annotate --no-version --write-index=tbi \\
             -h <(bcftools view -h {gvcf_input_group['base_gvcf']} | grep '^##GVCFBlock') \\
-            {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']}
+            {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']} -Oz
 
         """
     )

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -49,7 +49,7 @@ def reheader_mlr_gvcf(
 
 
         # Index the reheadered gVCF
-        bcftools index {reheadered_gvcf_outputs['gvcf.gz']}
+        bcftools index -t {reheadered_gvcf_outputs['gvcf.gz']}
         """
     )
 

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -476,6 +476,7 @@ class DownloadCramFromIca(SequencingGroupStage):
             sequencing_group=sequencing_group,
             file_spec=cram_spec,
             pipeline_id_arguid_path=pipeline_id_arguid_path,
+            gcs_output_dir=outputs['cram'].parent,
         )
 
         return self.make_outputs(
@@ -536,6 +537,7 @@ class DownloadGvcfFromIca(SequencingGroupStage):
             sequencing_group=sequencing_group,
             file_spec=base_gvcf_spec,
             pipeline_id_arguid_path=pipeline_id_arguid_path,
+            gcs_output_dir=outputs['gvcf'].parent,
         )
 
         return self.make_outputs(
@@ -598,6 +600,7 @@ class DownloadMlrGvcfFromIca(SequencingGroupStage):
             sequencing_group=sequencing_group,
             file_spec=recal_gvcf_spec,
             pipeline_id_arguid_path=pipeline_id_arguid_path,
+            gcs_output_dir=outputs['gvcf'].parent,
         )
 
         return self.make_outputs(

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -778,6 +778,7 @@ class RunMultiQc(CohortStage):
         DownloadGvcfFromIca,
         DownloadMlrGvcfFromIca,
         DownloadDataFromIca,
+        ReheaderMlrGvcf,
         RunMultiQc,
         FastqIntakeQc,
     ]

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -29,6 +29,7 @@ from dragen_align_pa.jobs import (
     manage_dragen_pipeline,
     manage_md5_pipeline,
     prepare_ica_for_analysis,
+    reheader_mlr_gvcf,
     run_multiqc,
     somalier_extract,
     upload_data_to_ica,
@@ -545,8 +546,6 @@ class DownloadGvcfFromIca(SequencingGroupStage):
 
 
 @stage(
-    analysis_type='gvcf',
-    analysis_keys=['gvcf'],
     required_stages=[DownloadGvcfFromIca, ManageDragenMlr, ManageDragenPipeline],
 )
 class DownloadMlrGvcfFromIca(SequencingGroupStage):
@@ -555,8 +554,12 @@ class DownloadMlrGvcfFromIca(SequencingGroupStage):
         sequencing_group: SequencingGroup,
     ) -> dict[str, cpg_utils.Path]:
         return {
-            'gvcf': get_output_path(filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz'),
-            'gvcf_tbi': get_output_path(filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz.tbi'),
+            'gvcf': get_output_path(
+                filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz', category='tmp'
+            ),
+            'gvcf_tbi': get_output_path(
+                filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz.tbi', category='tmp'
+            ),
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput:
@@ -705,6 +708,41 @@ class SomalierExtract(SequencingGroupStage):
             )
         # If can_reuse returns None, job is skipped
         return self.make_outputs(sequencing_group, data=out_somalier_path, skipped=True)
+
+
+@stage(required_stages=[DownloadGvcfFromIca, DownloadMlrGvcfFromIca], analysis_type='gvcf', analysis_keys=['gvcf'])
+class ReheaderMlrGvcf(SequencingGroupStage):
+    """
+    Reheader the MLR gVCF to insert correct reference block information that the MLR process removes.
+    """
+
+    def expected_outputs(self, sequencing_group: SequencingGroup) -> dict[str, cpg_utils.Path]:
+        return {
+            'gvcf': get_output_path(filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz'),
+            'gvcf_tbi': get_output_path(filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz.tbi'),
+        }
+
+    def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:
+
+        outputs: dict[str, cpg_utils.Path] = self.expected_outputs(sequencing_group=sequencing_group)
+
+        base_gvcf_path: cpg_utils.Path = inputs.as_path(
+            target=sequencing_group,
+            stage=DownloadGvcfFromIca,
+            key='gvcf',
+        )
+        recal_gvcf_path: cpg_utils.Path = inputs.as_path(
+            target=sequencing_group,
+            stage=DownloadMlrGvcfFromIca,
+            key='gvcf',
+        )
+        reheader_mlr_gvcf_job: BashJob = reheader_mlr_gvcf.reheader_mlr_gvcf(
+            base_gvcf_path=base_gvcf_path,
+            recal_gvcf_path=recal_gvcf_path,
+            reheadered_gvcf_path=outputs['gvcf'],
+        )
+
+        return self.make_outputs(target=sequencing_group, data=outputs, jobs=reheader_mlr_gvcf_job)  # pyright: ignore[reportArgumentType]
 
 
 @stage(required_stages=[DownloadDataFromIca, SomalierExtract])


### PR DESCRIPTION
# Purpose

  - The `##GVCFBlock` header information is missing from the gVCFs produced by Dragen MLR. This PR reintroduces them into the header.

## Proposed Changes

  - Download MLR gVCF from ICA into `tmp` storage.
  - Add new stage to reheader the MLR gVCF and write it to permanent storage.
  - Fix a related bug that was stopping data being downloaded into `tmp` storage. 

## Checklist

- Verified using `fewgenomes-test` that MLR gVCFs now contain `##GVCFBlock` information in the header, at the same location as the base gVCF.