### PR TITLE
Per-cohort exome target beds

### DIFF
--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -94,8 +94,11 @@ dragmap = 'fol.df2129db2c88419cbe0408dd600dce1f'
 gatk = ''
 
 [ica.reference_data]
-# Union of the two probesets for testing
-exome_bed = 'fil.56427f11f4964bf4193008de8a9fc7b1'
+# Per-design exome target bed (used as vc_target, cnv_target, and sv_call_regions).
+# Only consumed when [workflow].sequencing_type = 'exome'. Override per-cohort with the
+# matching CANONICAL_TO_BED_ID value from constants.py; the pipeline hard-fails at the
+# first stage if cohort design and configured bed disagree.
+exome_bed = 'PLACEHOLDER-set-per-cohort-do-not-run-with-this-value'
 
 [ica.qc]
 cross_cont_vcf = 'fil.1a7a2d0442854127e5d608da2935b1b0'

--- a/config/dragen_align_pa_mackenzie_cre.toml
+++ b/config/dragen_align_pa_mackenzie_cre.toml
@@ -6,8 +6,7 @@
 
 [workflow]
 sequencing_type = 'exome'
-# TODO: replace with the real metamist cohort ID for Mackenzie CRE samples.
-input_cohorts = ['COH_PLACEHOLDER_MACKENZIE_CRE']
+input_cohorts = ['COH12414']  # mackenzie-exome-cre-20260515-dragen (6 SGs)
 
 [ica.reference_data]
 exome_bed = 'PLACEHOLDER-cre-bed-not-yet-uploaded-to-ica'

--- a/config/dragen_align_pa_mackenzie_cre.toml
+++ b/config/dragen_align_pa_mackenzie_cre.toml
@@ -1,0 +1,13 @@
+# Per-cohort overlay for the Mackenzie Agilent Clinical Research Exome (CRE, v1) batch.
+# Layered on top of dragen_align_pa_defaults.toml via CPG_CONFIG_PATH.
+# The exome_bed value here must match CANONICAL_TO_BED_ID['CRE'] in
+# src/dragen_align_pa/constants.py; PrepareIcaForDragenAnalysis hard-fails at the
+# first stage if cohort design and configured bed disagree.
+
+[workflow]
+sequencing_type = 'exome'
+# TODO: replace with the real metamist cohort ID for Mackenzie CRE samples.
+input_cohorts = ['COH_PLACEHOLDER_MACKENZIE_CRE']
+
+[ica.reference_data]
+exome_bed = 'PLACEHOLDER-cre-bed-not-yet-uploaded-to-ica'

--- a/config/dragen_align_pa_mackenzie_crev2.toml
+++ b/config/dragen_align_pa_mackenzie_crev2.toml
@@ -1,0 +1,14 @@
+# Per-cohort overlay for the Mackenzie Agilent Clinical Research Exome v2 (CREv2) batch.
+# Layered on top of dragen_align_pa_defaults.toml via CPG_CONFIG_PATH.
+# The exome_bed value here must match CANONICAL_TO_BED_ID['CREv2'] in
+# src/dragen_align_pa/constants.py; PrepareIcaForDragenAnalysis hard-fails at the
+# first stage if cohort design and configured bed disagree.
+
+[workflow]
+sequencing_type = 'exome'
+# TODO: replace with the real metamist cohort ID for Mackenzie CREv2 samples
+# (~5k @ Facility A + ~1k @ Facility B; pooled here, facility tracked downstream).
+input_cohorts = ['COH_PLACEHOLDER_MACKENZIE_CREV2']
+
+[ica.reference_data]
+exome_bed = 'PLACEHOLDER-crev2-bed-not-yet-uploaded-to-ica'

--- a/config/dragen_align_pa_mackenzie_crev2.toml
+++ b/config/dragen_align_pa_mackenzie_crev2.toml
@@ -6,9 +6,7 @@
 
 [workflow]
 sequencing_type = 'exome'
-# TODO: replace with the real metamist cohort ID for Mackenzie CREv2 samples
-# (~5k @ Facility A + ~1k @ Facility B; pooled here, facility tracked downstream).
-input_cohorts = ['COH_PLACEHOLDER_MACKENZIE_CREV2']
+input_cohorts = ['COH12422']  # mackenzie-exome-crev2-20260515-dragen (6748 SGs)
 
 [ica.reference_data]
 exome_bed = 'PLACEHOLDER-crev2-bed-not-yet-uploaded-to-ica'

--- a/config/dragen_align_pa_mackenzie_twist.toml
+++ b/config/dragen_align_pa_mackenzie_twist.toml
@@ -6,8 +6,7 @@
 
 [workflow]
 sequencing_type = 'exome'
-# TODO: replace with the real metamist cohort ID for Mackenzie Twist samples (~5k).
-input_cohorts = ['COH_PLACEHOLDER_MACKENZIE_TWIST']
+input_cohorts = ['COH12430']  # mackenzie-exome-twist-20260515-dragen (5191 SGs)
 
 [ica.reference_data]
 exome_bed = 'PLACEHOLDER-twist-bed-not-yet-uploaded-to-ica'

--- a/config/dragen_align_pa_mackenzie_twist.toml
+++ b/config/dragen_align_pa_mackenzie_twist.toml
@@ -1,0 +1,13 @@
+# Per-cohort overlay for the Mackenzie Twist Comprehensive Exome + custom content batch.
+# Layered on top of dragen_align_pa_defaults.toml via CPG_CONFIG_PATH.
+# The exome_bed value here must match CANONICAL_TO_BED_ID['TWIST'] in
+# src/dragen_align_pa/constants.py; PrepareIcaForDragenAnalysis hard-fails at the
+# first stage if cohort design and configured bed disagree.
+
+[workflow]
+sequencing_type = 'exome'
+# TODO: replace with the real metamist cohort ID for Mackenzie Twist samples (~5k).
+input_cohorts = ['COH_PLACEHOLDER_MACKENZIE_TWIST']
+
+[ica.reference_data]
+exome_bed = 'PLACEHOLDER-twist-bed-not-yet-uploaded-to-ica'

--- a/src/dragen_align_pa/constants.py
+++ b/src/dragen_align_pa/constants.py
@@ -18,13 +18,11 @@ CANONICAL_DESIGN_CREV2: Final = 'CREv2'
 CANONICAL_DESIGN_TWIST: Final = 'TWIST'
 CANONICAL_DESIGNS: Final = frozenset({CANONICAL_DESIGN_CRE, CANONICAL_DESIGN_CREV2, CANONICAL_DESIGN_TWIST})
 
-# Map raw metamist sequencing_library / capture-kit values to canonical designs. Populate
-# as new values are encountered in metamist (the assay.meta['sequencing_library'] field is
-# the source). Codes encountered at CPG to date appear as substrings of read filenames or
-# sequencing_library.
+# Exact-match map from metamist assay.meta['sequencing_library'] values to canonical designs.
+# Populate as new values are encountered in metamist. Exact match (rather than substring) avoids
+# prefix collisions like SSQXTCRE ⊂ SSQXTCREV2.
 DESIGN_TO_CANONICAL: Final[dict[str, str]] = {
     'SSQXTCRE': CANONICAL_DESIGN_CRE,
-    'SSXTLICRE': CANONICAL_DESIGN_CRE,
     'SSQXTCREV2': CANONICAL_DESIGN_CREV2,
     'SSXTLICREV2': CANONICAL_DESIGN_CREV2,
     'TwistWES1VCGS1': CANONICAL_DESIGN_TWIST,

--- a/src/dragen_align_pa/constants.py
+++ b/src/dragen_align_pa/constants.py
@@ -23,10 +23,12 @@ CANONICAL_DESIGNS: Final = frozenset({CANONICAL_DESIGN_CRE, CANONICAL_DESIGN_CRE
 # the source). Codes encountered at CPG to date appear as substrings of read filenames or
 # sequencing_library.
 DESIGN_TO_CANONICAL: Final[dict[str, str]] = {
+    'SSQXTCRE': CANONICAL_DESIGN_CRE,
     'SSXTLICRE': CANONICAL_DESIGN_CRE,
     'SSQXTCREV2': CANONICAL_DESIGN_CREV2,
     'SSXTLICREV2': CANONICAL_DESIGN_CREV2,
     'TwistWES1VCGS1': CANONICAL_DESIGN_TWIST,
+    'AgilentCREv2WES': CANONICAL_DESIGN_CREV2,
 }
 
 # Canonical design -> ICA file ID for the (unpadded) target bed used for vc_target,

--- a/src/dragen_align_pa/constants.py
+++ b/src/dragen_align_pa/constants.py
@@ -11,3 +11,29 @@ READS_TYPE: Final = _reads_type.lower()
 BUCKET: Final = cpg_utils.to_path(output_path(suffix=''))
 BUCKET_NAME: Final = str(BUCKET).removeprefix('gs://').removesuffix('/')
 DRAGEN_VERSION: Final = config_retrieve(['ica', 'pipelines', 'dragen_version'])
+
+# Canonical exome design names. Each per-cohort exome run must resolve to exactly one.
+CANONICAL_DESIGN_CRE: Final = 'CRE'
+CANONICAL_DESIGN_CREV2: Final = 'CREv2'
+CANONICAL_DESIGN_TWIST: Final = 'TWIST'
+CANONICAL_DESIGNS: Final = frozenset({CANONICAL_DESIGN_CRE, CANONICAL_DESIGN_CREV2, CANONICAL_DESIGN_TWIST})
+
+# Map raw metamist library_type / capture-kit values to canonical designs. Populate as new
+# values are encountered in metamist (the assay.meta['library_type'] field is the source).
+# Codes encountered at CPG to date appear as substrings of read filenames or library_type.
+DESIGN_TO_CANONICAL: Final[dict[str, str]] = {
+    'SSXTLICRE': CANONICAL_DESIGN_CRE,
+    'SSQXTCREV2': CANONICAL_DESIGN_CREV2,
+    'SSXTLICREV2': CANONICAL_DESIGN_CREV2,
+    'TwistWES1VCGS1': CANONICAL_DESIGN_TWIST,
+}
+
+# Canonical design -> ICA file ID for the (unpadded) target bed used for vc_target,
+# cnv_target, and sv_call_regions. Populate with real fil.* IDs once beds are uploaded
+# to ICA. Placeholders below are intentionally not in fil.XXX format so they cannot be
+# mistaken for real ICA artefacts.
+CANONICAL_TO_BED_ID: Final[dict[str, str]] = {
+    CANONICAL_DESIGN_CRE: 'PLACEHOLDER-cre-bed-not-yet-uploaded-to-ica',
+    CANONICAL_DESIGN_CREV2: 'PLACEHOLDER-crev2-bed-not-yet-uploaded-to-ica',
+    CANONICAL_DESIGN_TWIST: 'PLACEHOLDER-twist-bed-not-yet-uploaded-to-ica',
+}

--- a/src/dragen_align_pa/constants.py
+++ b/src/dragen_align_pa/constants.py
@@ -18,9 +18,10 @@ CANONICAL_DESIGN_CREV2: Final = 'CREv2'
 CANONICAL_DESIGN_TWIST: Final = 'TWIST'
 CANONICAL_DESIGNS: Final = frozenset({CANONICAL_DESIGN_CRE, CANONICAL_DESIGN_CREV2, CANONICAL_DESIGN_TWIST})
 
-# Map raw metamist library_type / capture-kit values to canonical designs. Populate as new
-# values are encountered in metamist (the assay.meta['library_type'] field is the source).
-# Codes encountered at CPG to date appear as substrings of read filenames or library_type.
+# Map raw metamist sequencing_library / capture-kit values to canonical designs. Populate
+# as new values are encountered in metamist (the assay.meta['sequencing_library'] field is
+# the source). Codes encountered at CPG to date appear as substrings of read filenames or
+# sequencing_library.
 DESIGN_TO_CANONICAL: Final[dict[str, str]] = {
     'SSXTLICRE': CANONICAL_DESIGN_CRE,
     'SSQXTCREV2': CANONICAL_DESIGN_CREV2,

--- a/src/dragen_align_pa/jobs/ica_pipeline_manager.py
+++ b/src/dragen_align_pa/jobs/ica_pipeline_manager.py
@@ -128,7 +128,8 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                         if 'ar_guid' in data:
                             preserved_ar_guid_for_target = data['ar_guid']
                             logger.info(
-                                f"Preserved AR GUID '{preserved_ar_guid_for_target}' from existing file for {target.name}."
+                                f"Preserved AR GUID '{preserved_ar_guid_for_target}' "
+                                f'from existing file for {target.name}.'
                             )
                 except (json.JSONDecodeError, KeyError) as e:
                     logger.warning(f"Could not read AR GUID from {pipeline_id_arguid_file}: {e}.")
@@ -150,8 +151,8 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
         for target in monitored_targets:
             if is_finished(target):
                 continue
-            target_name: str = target.name
-            pipeline_id_arguid_file: cpg_utils.Path = outputs[
+            target_name = target.name
+            pipeline_id_arguid_file = outputs[
                 pipeline_id_file_key_template.format(target_name=target_name)
             ]
 
@@ -198,7 +199,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                 elif pipeline_status == 'SUCCEEDED':
                     target.set_status(new_status=PipelineStatus.SUCCEEDED)
                     logger.info(f'{pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}')
-                    pipeline_success_file: cpg_utils.Path = outputs[
+                    pipeline_success_file = outputs[
                         success_file_key_template.format(target_name=target_name)
                     ]
                     with pipeline_success_file.open('w') as success_file:

--- a/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
+++ b/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
@@ -102,7 +102,10 @@ def _prepare_fastq_inputs(
             + (
                 '--qc-coverage-reports-1 cov_report,cov_report '
                 if config_retrieve(['workflow', 'sequencing_type']) == 'genome'
-                else '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
+                else (
+                    '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
+                    '--vc-target-bed-padding 50 '
+                )
             ),
         ),
     ]
@@ -163,7 +166,10 @@ def _build_cram_specific_inputs(
                 + (
                     '--qc-coverage-reports-1 cov_report,cov_report '
                     if config_retrieve(['workflow', 'sequencing_type']) == 'genome'
-                    else '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
+                    else (
+                        '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
+                        '--vc-target-bed-padding 50 '
+                    )
                 ),
             ),
         ]

--- a/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
+++ b/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
@@ -102,10 +102,7 @@ def _prepare_fastq_inputs(
             + (
                 '--qc-coverage-reports-1 cov_report,cov_report '
                 if config_retrieve(['workflow', 'sequencing_type']) == 'genome'
-                else (
-                    '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
-                    '--vc-target-bed-padding 50 '
-                )
+                else '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
             ),
         ),
     ]
@@ -166,10 +163,7 @@ def _build_cram_specific_inputs(
                 + (
                     '--qc-coverage-reports-1 cov_report,cov_report '
                     if config_retrieve(['workflow', 'sequencing_type']) == 'genome'
-                    else (
-                        '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
-                        '--vc-target-bed-padding 50 '
-                    )
+                    else '--cnv-interval-width 500 --cnv-merge-threshold 0.4 --sv-exome true '
                 ),
             ),
         ]

--- a/src/dragen_align_pa/jobs/somalier_extract.py
+++ b/src/dragen_align_pa/jobs/somalier_extract.py
@@ -57,7 +57,7 @@ def somalier_extract(
         }
     )
 
-    declared_output_file = somalier_job.somalier_output.somalier_file
+    declared_output_file = somalier_job.somalier_output.somalier_file  # type: ignore[attr-defined]
 
     somalier_job.command(
         f"""

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -36,6 +36,7 @@ from dragen_align_pa.jobs import (
     validate_md5_sums,
 )
 from dragen_align_pa.utils import (
+    assert_cohort_design_matches_configured_bed,
     calculate_needed_storage,
     get_manifest_path_for_cohort,
     get_output_path,
@@ -71,6 +72,10 @@ class PrepareIcaForDragenAnalysis(CohortStage):
         return results
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:  # noqa: ARG002
+        # Fail fast: in exome mode, refuse to start if the cohort is design-mixed or
+        # the configured exome_bed does not match the cohort's design.
+        assert_cohort_design_matches_configured_bed(cohort)
+
         outputs: dict[str, cpg_utils.Path] = self.expected_outputs(cohort=cohort)
 
         job: PythonJob = initialise_python_job(

--- a/src/dragen_align_pa/utils.py
+++ b/src/dragen_align_pa/utils.py
@@ -6,13 +6,17 @@ from typing import TYPE_CHECKING, Any
 import cpg_utils
 from cloudpathlib.exceptions import NoStatError
 from cpg_flow.targets import Cohort, SequencingGroup
-from cpg_utils.config import get_access_level, get_driver_image, output_path
+from cpg_utils.config import config_retrieve, get_access_level, get_driver_image, output_path
 from cpg_utils.hail_batch import get_batch
 from hailtop.batch.job import PythonJob
 from loguru import logger
 from metamist.graphql import gql, query
 
-from dragen_align_pa.constants import DRAGEN_VERSION
+from dragen_align_pa.constants import (
+    CANONICAL_TO_BED_ID,
+    DESIGN_TO_CANONICAL,
+    DRAGEN_VERSION,
+)
 
 if TYPE_CHECKING:
     from graphql import DocumentNode
@@ -92,6 +96,92 @@ def run_subprocess_with_log(
         logger.error(f'STDOUT: {e.stdout}')
         logger.error(f'STDERR: {e.stderr}')
         raise
+
+
+def _resolve_sg_canonical_design(sg: SequencingGroup) -> str:
+    """Resolve a SequencingGroup's canonical exome design from its assay metadata.
+
+    Looks up assay.meta['library_type'] across the SG's assays, maps each through
+    DESIGN_TO_CANONICAL (substring match -- metamist values are not normalised), and
+    requires exactly one canonical design across the SG.
+    """
+    raw_values: set[str] = set()
+    for assay in sg.assays or ():
+        library_type = assay.meta.get('library_type')
+        if library_type:
+            raw_values.add(str(library_type))
+    if not raw_values:
+        raise RuntimeError(
+            f"Sequencing group {sg.id} has no assay.meta['library_type']; cannot resolve exome design.",
+        )
+
+    canonical: set[str] = set()
+    unmapped: set[str] = set()
+    for raw in raw_values:
+        match = next((c for key, c in DESIGN_TO_CANONICAL.items() if key in raw), None)
+        if match is None:
+            unmapped.add(raw)
+        else:
+            canonical.add(match)
+    if unmapped:
+        raise RuntimeError(
+            f'Sequencing group {sg.id} has unmapped library_type value(s): {sorted(unmapped)}. '
+            f'Add these to DESIGN_TO_CANONICAL in constants.py.',
+        )
+    if len(canonical) != 1:
+        raise RuntimeError(
+            f'Sequencing group {sg.id} maps to multiple canonical designs: {sorted(canonical)}.',
+        )
+    return canonical.pop()
+
+
+def assert_cohort_design_matches_configured_bed(cohort: Cohort) -> None:
+    """Hard-fail check for exome runs: cohort is design-homogeneous and matches the configured bed.
+
+    Only runs when workflow.sequencing_type == 'exome'. Verifies:
+      1. Every SG in the cohort resolves to the same canonical design.
+      2. The configured [ica.reference_data].exome_bed matches CANONICAL_TO_BED_ID for that design.
+
+    Why: a single ICA DRAGEN submit takes one bed for vc/cnv/sv targets. Mixed designs in a
+    cohort, or a config pointing at the wrong bed, silently produce garbage CNV/SV calls and
+    SNV false-negatives in design-disjoint regions.
+    """
+    if config_retrieve(['workflow', 'sequencing_type']) != 'exome':
+        return
+
+    sgs = cohort.get_sequencing_groups()
+    if not sgs:
+        raise RuntimeError(f'Cohort {cohort.id} has no sequencing groups.')
+
+    designs: dict[str, str] = {sg.id: _resolve_sg_canonical_design(sg) for sg in sgs}
+    unique_designs = set(designs.values())
+    if len(unique_designs) != 1:
+        by_design: dict[str, list[str]] = {}
+        for sg_id, d in designs.items():
+            by_design.setdefault(d, []).append(sg_id)
+        raise RuntimeError(
+            f'Cohort {cohort.id} has mixed exome designs {sorted(unique_designs)}. '
+            f'Split into one cohort per design. Breakdown: {by_design}',
+        )
+    cohort_design = unique_designs.pop()
+
+    configured_bed = config_retrieve(['ica', 'reference_data', 'exome_bed'])
+    expected_bed = CANONICAL_TO_BED_ID.get(cohort_design)
+    if expected_bed is None:
+        raise RuntimeError(
+            f'No CANONICAL_TO_BED_ID entry for design {cohort_design!r}; update constants.py.',
+        )
+    if configured_bed != expected_bed:
+        bed_to_design = {v: k for k, v in CANONICAL_TO_BED_ID.items()}
+        configured_design = bed_to_design.get(configured_bed, '<unknown>')
+        raise RuntimeError(
+            f'Configured exome_bed {configured_bed!r} (design={configured_design}) does not match '
+            f'cohort {cohort.id} design {cohort_design!r} (expected bed {expected_bed!r}). '
+            'Check the TOML against the cohort.',
+        )
+    logger.info(
+        f'Exome design check passed: cohort {cohort.id} -> {cohort_design}, bed {configured_bed!r}.',
+    )
 
 
 def initialise_python_job(

--- a/src/dragen_align_pa/utils.py
+++ b/src/dragen_align_pa/utils.py
@@ -101,31 +101,31 @@ def run_subprocess_with_log(
 def _resolve_sg_canonical_design(sg: SequencingGroup) -> str:
     """Resolve a SequencingGroup's canonical exome design from its assay metadata.
 
-    Looks up assay.meta['library_type'] across the SG's assays, maps each through
-    DESIGN_TO_CANONICAL (substring match -- metamist values are not normalised), and
-    requires exactly one canonical design across the SG.
+    Looks up assay.meta['sequencing_library'] across the SG's assays, maps each through
+    DESIGN_TO_CANONICAL (exact match -- metamist values are clean, single-token codes),
+    and requires exactly one canonical design across the SG.
     """
     raw_values: set[str] = set()
     for assay in sg.assays or ():
-        library_type = assay.meta.get('library_type')
-        if library_type:
-            raw_values.add(str(library_type))
+        sequencing_library = assay.meta.get('sequencing_library')
+        if sequencing_library:
+            raw_values.add(str(sequencing_library))
     if not raw_values:
         raise RuntimeError(
-            f"Sequencing group {sg.id} has no assay.meta['library_type']; cannot resolve exome design.",
+            f"Sequencing group {sg.id} has no assay.meta['sequencing_library']; cannot resolve exome design.",
         )
 
     canonical: set[str] = set()
     unmapped: set[str] = set()
     for raw in raw_values:
-        match = next((c for key, c in DESIGN_TO_CANONICAL.items() if key in raw), None)
+        match = DESIGN_TO_CANONICAL.get(raw)
         if match is None:
             unmapped.add(raw)
         else:
             canonical.add(match)
     if unmapped:
         raise RuntimeError(
-            f'Sequencing group {sg.id} has unmapped library_type value(s): {sorted(unmapped)}. '
+            f'Sequencing group {sg.id} has unmapped sequencing_library value(s): {sorted(unmapped)}. '
             f'Add these to DESIGN_TO_CANONICAL in constants.py.',
         )
     if len(canonical) != 1:


### PR DESCRIPTION
the work on branch `feat-exomes` is currently configured to run all Mackenzie exomes against a single union bed. We have also updated our understanding of the VCGS exome design. Setting each sub-cohort to use it's specific design bedfile improves design-sensitive metrics (CNV/SV, exonic recall). 

This PR splits into one TOML per design (CRE, CREv2, Twist) and adds a fail-fast validator at `PrepareIcaForDragenAnalysis` that checks cohort homogeneity and matches the configured bed against `CANONICAL_TO_BED_ID`.

**NB:** The bed IDs in `CANONICAL_TO_BED_ID` and the three per-cohort TOMLs are intentional `PLACEHOLDER-*-not-yet-uploaded-to-ica` strings — deliberately not `fil.XXX` shape so they can't be mistaken for real artefacts. 
I suggest that real IDs land in a small follow-up PR once the references-repo BEDs are uploaded to ICA. `input_cohorts` and any missing `DESIGN_TO_CANONICAL` entries get filled at the same time, after a metamist census.

Commit `2d4879b` also clears 5 pre-existing lint diagnostics inherited from `feat-exomes` — unrelated to the per-design work.

**Open question:** for CREv2 (the only design shipping distinct Regions vs Covered BEDs), should `vc_target` use the larger Covered to catch probe-overhang variants while `cnv_target` / `sv_call_regions` stay on the smaller Regions for CNV resolution, or should all three uniformly use Regions (relying on `--vc-target-bed-padding` from the upstream branch to cover probe overhang)?


