### PR TITLE
Fix somalier_extract output discovery (use glob, not CRAM basename)

### DIFF
--- a/src/dragen_align_pa/jobs/somalier_extract.py
+++ b/src/dragen_align_pa/jobs/somalier_extract.py
@@ -74,14 +74,26 @@ def somalier_extract(
         -f {b_ref_fasta} \\
         {b_cram['cram']}
 
-        # Find the output file somalier created
-        CRAM_BASENAME=$(basename {b_cram['cram']})
-        SOMALIER_OUTPUT_NAME=${{CRAM_BASENAME%.cram}}.somalier
-        CREATED_FILE_PATH=$TMP_OUT_DIR/$SOMALIER_OUTPUT_NAME
+        # somalier names its output `<SM>.somalier` where <SM> is the @RG SM
+        # tag from the CRAM header (see brentp/somalier@v0.3.1:src/somalier.nim
+        # `let fname = opts.outdir & "/" & cnts.sample_name & ".somalier"`),
+        # NOT the input filename. Discover the actual file by globbing
+        # instead of deriving the name from the CRAM basename — `somalier
+        # extract` writes exactly one `.somalier` per single-sample CRAM
+        # into the output dir, so the glob is unambiguous.
+        shopt -s nullglob
+        CREATED_FILES=("$TMP_OUT_DIR"/*.somalier)
+        shopt -u nullglob
+        if [[ ${{#CREATED_FILES[@]}} -ne 1 ]]; then
+            echo "Expected exactly 1 .somalier file in $TMP_OUT_DIR; found ${{#CREATED_FILES[@]}}" >&2
+            ls -la "$TMP_OUT_DIR" >&2
+            exit 1
+        fi
+        CREATED_FILE_PATH="${{CREATED_FILES[0]}}"
 
         # Move the created file to the *path* of the declared resource.
         # {declared_output_file} interpolates as a string path.
-        mv $CREATED_FILE_PATH {declared_output_file}
+        mv "$CREATED_FILE_PATH" {declared_output_file}
         """
     )
 


### PR DESCRIPTION
## Summary

Fix a `somalier_extract` stage failure on `main`: the bash block was deriving the somalier output path by stripping `.cram` off the input filename, but `somalier extract` names its output by the `@RG SM:` tag from the CRAM header, not by the input filename. CRAMs whose SM tag differs from their filename stem fail with `mv: cannot stat … No such file or directory`.

## Root cause

`brentp/somalier@v0.3.1` (`src/somalier.nim`):

```nim
let fname = opts.outdir & "/" & cnts.sample_name & ".somalier"
```

where `cnts.sample_name` is populated from the BAM/CRAM `@RG SM:` tag. The script's previous assumption (`${CRAM_BASENAME%.cram}.somalier`) only holds when `SM:` == filename stem — not guaranteed for our inputs.

Side note: somalier 0.3.1's `--sample-prefix` flag affects only the sample name stored *inside* the digest, not the on-disk filename — it can't be used as a fix.

## Fix

Replace the filename derivation with a glob. `somalier extract` writes exactly one `.somalier` per single-sample CRAM into `-d`, so `$TMP_OUT_DIR/*.somalier` is unambiguous. Guard with `shopt -s nullglob` + an array-length check that surfaces a clear diagnostic (listing the output dir) on the never-supposed-to-happen zero-or-multiple-matches case.

## Affected run

Diagnosed on `CPGxxxxx`:

```
+ somalier extract -d /io/batch/e7494f/CPGxxxxx ... /io/batch/e7494f/inputs/W17dU/CPGxxxxx.cram
somalier version: 0.3.1
+ CREATED_FILE_PATH=/io/batch/e7494f/CPGxxxxx/CPGxxxxx.somalier
+ mv /io/batch/e7494f/CPGxxxxx/CPGxxxxx.somalier ...
mv: cannot stat '/io/batch/e7494f/CPGxxxxx/CPGxxxxx.somalier': No such file or directory
```

The on-call diagnostic to confirm `SM != filename stem` for any affected sample is:

```bash
samtools view -H gs://<cram-bucket>/<sg>.cram | grep '^@RG'
```

After this lands, rerun the affected stage — the GCS output path is deterministic and the stage is safe to re-run.

## Test plan

- [x] `pre-commit run --files src/dragen_align_pa/jobs/somalier_extract.py` — ruff, mypy, all default hooks pass.
- [x] F-string renders to syntactically valid bash (verified with `bash -n` on the interpolated output).
- [ ] **Real run** — once merged, rerun `Somalier_extract` for the failed sample (CPG155325) and confirm it lands the `.somalier` file in GCS. The blast radius for a glob-based discovery is contained: even if `SM == filename stem` (the old-happy-path case), the new code still picks up the file correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)