### PR TITLE
Cache + retry get_ica_secrets() against Secret Manager transients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies=[
     'cpg-flow>=v1.0.1',
     'loguru',
     'pandas',
+    'tenacity',
 ]
 
 [project.urls]

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -5,17 +5,25 @@ wrappers around specific API endpoints.
 """
 
 import contextlib
+import functools
 import json
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import icasdk
+from google.api_core import exceptions as gax_exceptions
 from google.cloud import secretmanager
 from icasdk import ApiClient, Configuration
 from icasdk.apis.tags import project_analysis_api, project_data_api
 from icasdk.exceptions import ApiException
 from icasdk.model.create_nextflow_analysis import CreateNextflowAnalysis
 from loguru import logger
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -32,12 +40,40 @@ SECRET_VERSION: Final = 'latest'
 
 # --- Secret Management & Auth ---
 
+# Secret Manager occasionally returns gRPC 504 (DeadlineExceeded) on transient
+# load spikes; GAPIC's default retry policy does NOT cover DeadlineExceeded,
+# so a single blip propagates and crashes whichever job is calling. We retry
+# both that and ServiceUnavailable (gRPC UNAVAILABLE / HTTP 503).
+_TRANSIENT_SECRET_MANAGER_EXCEPTIONS: Final = (
+    gax_exceptions.DeadlineExceeded,
+    gax_exceptions.ServiceUnavailable,
+)
 
+
+@functools.lru_cache(maxsize=1)
+@retry(
+    retry=retry_if_exception_type(_TRANSIENT_SECRET_MANAGER_EXCEPTIONS),
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    reraise=True,
+)
 def get_ica_secrets() -> dict[Literal['projectID', 'apiKey'], str]:
-    """Gets the project ID and API key used to interact with ICA
+    """Gets the project ID and API key used to interact with ICA.
+
+    Cached for the lifetime of the process (the secret payload doesn't
+    change during a run). The previous behaviour fetched fresh on every
+    monitor-loop poll and every batch submission, which meant a single
+    transient Secret Manager 504 could tear down a long-running monitor
+    job. With the cache, only the very first call hits Secret Manager; all
+    subsequent calls return the cached dict without an RPC.
+
+    Retries transient Secret Manager failures (DeadlineExceeded /
+    ServiceUnavailable) with exponential backoff before giving up. Other
+    error classes (e.g. PermissionDenied, NotFound) propagate immediately
+    — they indicate IAM / config problems that retrying won't fix.
 
     Returns:
-        dict[str, str]: A dictionary with the keys projectId and apiKey
+        dict[str, str]: A dictionary with the keys projectID and apiKey
     """
     secret_path: str = SECRET_CLIENT.secret_version_path(
         project=SECRET_PROJECT,

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -1,0 +1,166 @@
+"""Tests for ica_api_utils.get_ica_secrets — Secret Manager resilience.
+
+Production hit `google.api_core.exceptions.DeadlineExceeded` (gRPC 504) from
+`SECRET_CLIENT.access_secret_version` inside `get_ica_secrets()`, tearing
+down monitor jobs mid-run. The secret payload doesn't change during a run,
+so the fix is two-fold: cache the result for the process lifetime, and
+retry on transient Secret Manager failures.
+
+GAPIC's default retry policy does NOT cover `DeadlineExceeded`, which is
+why these blips propagate unhandled.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from google.api_core import exceptions as gax_exceptions
+
+from dragen_align_pa import ica_api_utils
+
+
+@pytest.fixture(autouse=True)
+def _clear_ica_secrets_cache():
+    """get_ica_secrets is decorated with @lru_cache(maxsize=1) — clear between
+    tests so caching from one test doesn't bleed into the next."""
+    ica_api_utils.get_ica_secrets.cache_clear()
+    yield
+    ica_api_utils.get_ica_secrets.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _instant_retry_sleeps(monkeypatch):
+    """Tenacity sleeps between retries — patch time.sleep so the retry tests
+    don't take real wall-clock time. The retry logic is verified by call
+    counts and final outcomes, not by wait timings."""
+    monkeypatch.setattr('tenacity.nap.time.sleep', lambda _seconds: None)
+
+
+def _fake_access_secret_version_response(payload: dict) -> MagicMock:
+    """Build a stand-in for the AccessSecretVersionResponse returned by
+    SecretManagerServiceClient.access_secret_version."""
+    response = MagicMock()
+    response.payload.data = json.dumps(payload).encode('UTF-8')
+    return response
+
+
+def test_get_ica_secrets_returns_parsed_payload(monkeypatch):
+    """Happy-path regression: secret JSON → parsed dict."""
+    payload = {'projectID': 'proj-abc', 'apiKey': 'key-xyz'}
+    mock_client = MagicMock()
+    mock_client.access_secret_version.return_value = _fake_access_secret_version_response(payload)
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', mock_client)
+
+    result = ica_api_utils.get_ica_secrets()
+
+    assert result == payload
+
+
+def test_get_ica_secrets_caches_across_calls(monkeypatch):
+    """The secret doesn't change during a run; calling get_ica_secrets()
+    repeatedly (e.g. once per monitor poll, once per batch submission) must
+    hit Secret Manager exactly once — otherwise a single transient 504 takes
+    down the whole monitor job."""
+    payload = {'projectID': 'proj-abc', 'apiKey': 'key-xyz'}
+    mock_client = MagicMock()
+    mock_client.access_secret_version.return_value = _fake_access_secret_version_response(payload)
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', mock_client)
+
+    first = ica_api_utils.get_ica_secrets()
+    second = ica_api_utils.get_ica_secrets()
+    third = ica_api_utils.get_ica_secrets()
+
+    assert first == second == third == payload
+    assert mock_client.access_secret_version.call_count == 1, (
+        f'expected exactly one RPC; got {mock_client.access_secret_version.call_count}'
+    )
+
+
+def test_get_ica_secrets_retries_on_deadline_exceeded(monkeypatch):
+    """The originating production failure: SecretManagerServiceClient raises
+    DeadlineExceeded on a transient blip. The retry layer must absorb it and
+    return the value on the second attempt."""
+    payload = {'projectID': 'proj-abc', 'apiKey': 'key-xyz'}
+    mock_client = MagicMock()
+    mock_client.access_secret_version.side_effect = [
+        gax_exceptions.DeadlineExceeded('Secret Manager 504'),
+        _fake_access_secret_version_response(payload),
+    ]
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', mock_client)
+
+    result = ica_api_utils.get_ica_secrets()
+
+    assert result == payload
+    assert mock_client.access_secret_version.call_count == 2
+
+
+def test_get_ica_secrets_retries_on_service_unavailable(monkeypatch):
+    """ServiceUnavailable (gRPC UNAVAILABLE / HTTP 503) is the other
+    transient class — must also be retried."""
+    payload = {'projectID': 'proj-abc', 'apiKey': 'key-xyz'}
+    mock_client = MagicMock()
+    mock_client.access_secret_version.side_effect = [
+        gax_exceptions.ServiceUnavailable('Secret Manager 503'),
+        _fake_access_secret_version_response(payload),
+    ]
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', mock_client)
+
+    result = ica_api_utils.get_ica_secrets()
+
+    assert result == payload
+    assert mock_client.access_secret_version.call_count == 2
+
+
+def test_get_ica_secrets_gives_up_after_persistent_failures(monkeypatch):
+    """Persistent (non-transient) Secret Manager unavailability eventually
+    propagates after the retry budget is exhausted. The caller (cpg-flow
+    job) sees a real failure rather than silent infinite retry."""
+    mock_client = MagicMock()
+    mock_client.access_secret_version.side_effect = gax_exceptions.DeadlineExceeded('persistent 504')
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', mock_client)
+
+    with pytest.raises(gax_exceptions.DeadlineExceeded):
+        ica_api_utils.get_ica_secrets()
+
+    # At least some retries happened — confirms the retry layer is active.
+    # The exact retry budget is configured in the production module; we just
+    # assert it's > 1 (i.e. more than the initial attempt).
+    assert mock_client.access_secret_version.call_count > 1
+
+
+def test_get_ica_secrets_does_not_retry_non_transient_errors(monkeypatch):
+    """A non-Secret-Manager-transient failure (e.g. PermissionDenied,
+    NotFound — IAM or config errors) must propagate immediately, not be
+    retried. Retrying a permanent error would just hammer Secret Manager
+    and delay the real failure signal."""
+    mock_client = MagicMock()
+    mock_client.access_secret_version.side_effect = gax_exceptions.PermissionDenied('forbidden')
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', mock_client)
+
+    with pytest.raises(gax_exceptions.PermissionDenied):
+        ica_api_utils.get_ica_secrets()
+
+    assert mock_client.access_secret_version.call_count == 1
+
+
+def test_get_ica_secrets_cache_skips_retry_layer_on_subsequent_calls(monkeypatch):
+    """After a successful first call populates the cache, a subsequent call
+    must NOT go anywhere near Secret Manager — even if the SECRET_CLIENT is
+    swapped for one that would raise. Belt-and-braces against the regression
+    Copilot warned about for #8 (loops re-firing callbacks)."""
+    payload = {'projectID': 'proj-abc', 'apiKey': 'key-xyz'}
+    happy_client = MagicMock()
+    happy_client.access_secret_version.return_value = _fake_access_secret_version_response(payload)
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', happy_client)
+    first = ica_api_utils.get_ica_secrets()
+    assert first == payload
+
+    angry_client = MagicMock()
+    angry_client.access_secret_version.side_effect = AssertionError(
+        'cache must short-circuit; SECRET_CLIENT must not be called on cache hit',
+    )
+    monkeypatch.setattr(ica_api_utils, 'SECRET_CLIENT', angry_client)
+    second = ica_api_utils.get_ica_secrets()
+
+    assert second == payload
+    angry_client.access_secret_version.assert_not_called()


### PR DESCRIPTION
## Summary

First of 5 PRs for Segment B of the unified DRAGEN pipeline migration. This one is the smallest, most independent piece — a defensive fix to `get_ica_secrets()` that production already needs regardless of the rest of Segment B.

**The problem:** production has hit `google.api_core.exceptions.DeadlineExceeded` (gRPC 504) from `SecretManagerServiceClient.access_secret_version` inside `get_ica_secrets()`, tearing down monitor jobs mid-run. Two compounding causes:

1. The secret payload is refetched on every monitor poll and every batch submission — a single transient Secret Manager 504 takes down the whole job, even though the payload doesn't change during a run.
2. GAPIC's default retry policy does **not** cover `DeadlineExceeded`, so the blip propagates unhandled.

**The fix:**

- `@functools.lru_cache(maxsize=1)` on `get_ica_secrets` — first call hits Secret Manager, all subsequent calls return the cached dict with no RPC.
- `@tenacity.retry` on the inner call with exponential backoff (1s → 10s, up to 4 attempts) restricted to `DeadlineExceeded` and `ServiceUnavailable`.
- Non-transient errors (`PermissionDenied`, `NotFound` — IAM / config issues) propagate immediately, since retrying them just hammers Secret Manager and delays the real failure signal.

## Test plan

- [x] `pytest -v` from this branch: **79 passed** (7 new in `tests/test_ica_api_utils.py`, all prior 72 still green).
- [x] New tests cover: happy path, caching across calls (asserts exactly one RPC), retry-then-succeed for both `DeadlineExceeded` and `ServiceUnavailable`, eventual give-up after the retry budget is exhausted, no-retry on `PermissionDenied`, cache-bypasses-retry-layer on cache hits.
- [x] `pre-commit run` clean (ruff v0.15.0 + mypy v1.19.1).
- [ ] **Not exercised:** real Secret Manager call (all tests mock `SECRET_CLIENT`); will be validated alongside the broader Segment B end-to-end runs.

## Segment B PR plan

This is PR 1 of 5:

1. **(this PR)** Secret Manager resilience — `lru_cache` + `tenacity` retry on `get_ica_secrets()`
2. Orchestrator rewrite + retry-batch tests (Tasks 15 + 14c)
3. Stage-input rewiring + new batch artefacts stage (Tasks 16 + 17 + 21)
4. Download-stage rewiring + MLR housekeeping (Tasks 18 + 19 + 19b + 20)
5. Delete obsolete legacy modules (Tasks 22 + 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)