### PR TITLE
Pin DRAGEN manager stages to non-preemptable workers

### DIFF
--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -323,6 +323,7 @@ class ManageDragenPipeline(CohortStage):
             tool_name='Dragen',
         )
         job.image(image=get_driver_image())
+        job.spot(is_spot=False)
 
         job.call(
             manage_dragen_pipeline.run,
@@ -371,6 +372,7 @@ class ManageDragenMlr(CohortStage):
             tool_name='ICA',
         )
         job.image(image=get_driver_image())
+        job.spot(is_spot=False)
 
         job.call(
             manage_dragen_mlr.run,


### PR DESCRIPTION
## Summary

`ManageDragenPipeline` and `ManageDragenMlr` orchestrate long-running ICA pipeline submissions and polling loops where preemption discards in-flight state and forces a full re-poll from the start. This can cause a desync between GCS and ICA, where the pipeline will start a second pipeline run in ICA, wasting hours of DRAGEN runtime. Pin both PythonJobs to non-preemptable workers, matching the existing pattern on `UploadDataToIca`.

## Changes

- `src/dragen_align_pa/stages.py` — add `job.spot(is_spot=False)` to both `ManageDragenPipeline` (line 326) and `ManageDragenMlr` (line 375), right after the existing `job.image(...)` call.

## Test plan

- [x] \`pre-commit run --files src/dragen_align_pa/stages.py\` (ruff, mypy, cpg-id-checker — all pass)
- [ ] Confirm in a real cohort run that both jobs land on non-preemptable workers (Hail Batch UI / job attributes)