### PR TITLE
ManageDragen*: route per-SG paths via tmp manifest + pin non-preempt

### DIFF
--- a/.github/workflows/get_version.py
+++ b/.github/workflows/get_version.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 import subprocess
@@ -34,8 +35,6 @@ def get_next_version_tag(folder: str, version: str) -> str:
     full_image_name_archive = f'{base_image_path_archive}/{folder}'
 
     tags_list = []
-    import logging
-
     logging.basicConfig(level=logging.ERROR)
     for full_image_name in [full_image_name_prod, full_image_name_archive]:
         cmd = [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     # Ruff version.
     rev: v0.15.0
     hooks:
-      - id: ruff
+      - id: ruff-check
 
   # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,13 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.3
+    rev: v0.15.0
     hooks:
       - id: ruff
 
   # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0"
+    rev: "v1.19.1"
     hooks:
       - id: mypy
         args: [--pretty, --show-error-codes, --install-types, --non-interactive]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.3.0
+ENV VERSION=3.4.0
 
 ARG ICA_CLI_VERSION="2.45.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.3.0
+## Pipeline Overview v3.4.0
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -28,7 +28,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.3.0-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.4.0-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # # currently cpg-flow is pinned to this version.
 # # Keep [tool.ruff] target-version and [tool.mypy] python_version in sync with this.
 requires-python = ">=3.11,<3.12"
-version="3.3.0"
+version="3.4.0"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "3.3.0"
+current_version = "3.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ python_version = "3.11"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-testpaths = ['test']
+testpaths = ['tests']
 
 [tool.ruff]
 line-length = 120

--- a/src/dragen_align_pa/jobs/download_specific_files_from_ica.py
+++ b/src/dragen_align_pa/jobs/download_specific_files_from_ica.py
@@ -128,9 +128,7 @@ def run(
     logger.info(f'Targeting ICA folder: {base_ica_folder_path}')
 
     # --- 3. Setup GCS Client ---
-    gcs_output_bucket_name, _, gcs_output_path_prefix = (
-        str(gcs_output_dir).removeprefix('gs://').partition('/')
-    )
+    gcs_output_bucket_name, _, gcs_output_path_prefix = str(gcs_output_dir).removeprefix('gs://').partition('/')
     storage_client = storage.Client()
     gcs_bucket = storage_client.bucket(gcs_output_bucket_name)
 

--- a/src/dragen_align_pa/jobs/ica_pipeline_manager.py
+++ b/src/dragen_align_pa/jobs/ica_pipeline_manager.py
@@ -132,14 +132,14 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                                 f'for {target.name}.'
                             )
                 except (json.JSONDecodeError, KeyError) as e:
-                    logger.warning(f"Could not read AR GUID from {pipeline_id_arguid_file}: {e}.")
+                    logger.warning(f'Could not read AR GUID from {pipeline_id_arguid_file}: {e}.')
 
                 pipeline_id_arguid_file.unlink()
-                logger.info(f"Deleted existing pipeline ID file: {pipeline_id_arguid_file}")
+                logger.info(f'Deleted existing pipeline ID file: {pipeline_id_arguid_file}')
 
             if pipeline_success_file.exists():
                 pipeline_success_file.unlink()
-                logger.info(f"Deleted existing success file: {pipeline_success_file}")
+                logger.info(f'Deleted existing success file: {pipeline_success_file}')
 
             # Set the ar_guid on the target object to be used for the new submission
             target.ar_guid = preserved_ar_guid_for_target
@@ -152,9 +152,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
             if is_finished(target):
                 continue
             target_name = target.name
-            pipeline_id_arguid_file = outputs[
-                pipeline_id_file_key_template.format(target_name=target_name)
-            ]
+            pipeline_id_arguid_file = outputs[pipeline_id_file_key_template.format(target_name=target_name)]
 
             if pipeline_id_arguid_file.exists() and not target.pipeline_id:
                 with pipeline_id_arguid_file.open('r') as pipeline_fid_handle:
@@ -199,9 +197,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                 elif pipeline_status == 'SUCCEEDED':
                     target.set_status(new_status=PipelineStatus.SUCCEEDED)
                     logger.info(f'{pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}')
-                    pipeline_success_file = outputs[
-                        success_file_key_template.format(target_name=target_name)
-                    ]
+                    pipeline_success_file = outputs[success_file_key_template.format(target_name=target_name)]
                     with pipeline_success_file.open('w') as success_file:
                         success_file.write(
                             f'ICA {pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}.'

--- a/src/dragen_align_pa/jobs/manage_dragen_mlr.py
+++ b/src/dragen_align_pa/jobs/manage_dragen_mlr.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 from collections.abc import Callable
 from functools import partial
-from typing import Any
+from typing import Any, cast
 
 import cpg_utils
 from cpg_flow.targets import Cohort
@@ -13,6 +13,7 @@ from loguru import logger
 from dragen_align_pa import ica_cli_utils, utils
 from dragen_align_pa.constants import BUCKET_NAME
 from dragen_align_pa.jobs.ica_pipeline_manager import manage_ica_pipeline_loop
+from dragen_align_pa.utils import load_manifest
 
 
 def _mlr_enter_project(mlr_project: str) -> None:
@@ -182,12 +183,17 @@ def _submit_mlr_run(
 
 def run(
     cohort: Cohort,
-    pipeline_id_arguid_path_dict: dict[str, cpg_utils.Path],
-    outputs: dict[str, cpg_utils.Path],
+    manifest_path: cpg_utils.Path,
 ) -> None:
     """
     Calls the generic pipeline manager with settings for the MLR pipeline.
     """
+    manifest = load_manifest(manifest_path)
+    outputs = cast('dict[str, cpg_utils.Path]', manifest['outputs'])
+    pipeline_id_arguid_path_dict = cast(
+        'dict[str, cpg_utils.Path]',
+        manifest['pipeline_id_arguid_path_dict'],
+    )
     ica_analysis_output_folder: str = config_retrieve(
         ['ica', 'data_prep', 'output_folder'],
     )

--- a/src/dragen_align_pa/jobs/manage_dragen_pipeline.py
+++ b/src/dragen_align_pa/jobs/manage_dragen_pipeline.py
@@ -1,11 +1,13 @@
 from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import cpg_utils
 from cpg_flow.targets import Cohort
 
 from dragen_align_pa.jobs import run_align_genotype_with_dragen
 from dragen_align_pa.jobs.ica_pipeline_manager import manage_ica_pipeline_loop
+from dragen_align_pa.utils import load_manifest
 
 
 def _submit_new_ica_pipeline(
@@ -27,15 +29,22 @@ def _submit_new_ica_pipeline(
 
 def run(
     cohort: Cohort,
-    outputs: dict[str, cpg_utils.Path],
-    cram_ica_fids_path: dict[str, cpg_utils.Path] | None,
-    analysis_output_fids_path: dict[str, cpg_utils.Path],
-    fastq_ids_path: cpg_utils.Path | None,
-    fastq_list_fid_and_filenames_path: dict[str, cpg_utils.Path] | None,
+    manifest_path: cpg_utils.Path,
 ) -> None:
     """
     Calls the generic pipeline manager with settings for the main Dragen pipeline.
     """
+    manifest = load_manifest(manifest_path)
+    # cast narrows the generic ManifestEntry union back to each value's known
+    # shape — write_manifest at the dispatcher is the schema source of truth.
+    outputs = cast('dict[str, cpg_utils.Path]', manifest['outputs'])
+    cram_ica_fids_path = cast('dict[str, cpg_utils.Path] | None', manifest['cram_ica_fids_path'])
+    analysis_output_fids_path = cast('dict[str, cpg_utils.Path]', manifest['analysis_output_fids_path'])
+    fastq_ids_path = cast('cpg_utils.Path | None', manifest['fastq_ids_path'])
+    fastq_list_fid_and_filenames_path = cast(
+        'dict[str, cpg_utils.Path] | None',
+        manifest['fastq_list_fid_and_filenames_path'],
+    )
 
     def _create_submit_callable(sg_name: str) -> Callable[[], str]:
         """Creates a zero-argument callable for pipeline submission."""

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from cpg_utils.config import image_path
 from cpg_utils.hail_batch import Batch, get_batch
@@ -36,7 +36,9 @@ def reheader_mlr_gvcf(
         }
     )
 
-    reheadered_gvcf_outputs = job.reheadered_gvcf
+    # mypy 1.19 narrows job.<resource_group_name> to the base Resource type,
+    # which isn't statically indexable; the runtime object is a ResourceGroup.
+    reheadered_gvcf_outputs: Any = job.reheadered_gvcf
 
     job.command(
         f"""

--- a/src/dragen_align_pa/jobs/somalier_extract.py
+++ b/src/dragen_align_pa/jobs/somalier_extract.py
@@ -57,7 +57,7 @@ def somalier_extract(
         }
     )
 
-    declared_output_file = somalier_job.somalier_output.somalier_file
+    declared_output_file = somalier_job.somalier_output.somalier_file  # type: ignore[attr-defined]
 
     somalier_job.command(
         f"""

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -44,6 +44,7 @@ from dragen_align_pa.utils import (
     get_prep_path,
     get_qc_path,
     initialise_python_job,
+    write_manifest,
 )
 
 if TYPE_CHECKING:
@@ -357,21 +358,36 @@ class ManageDragenPipeline(CohortStage):
             target=cohort, stage=PrepareIcaForDragenAnalysis
         )
 
+        # Collapse all per-SG path dicts into one tmp manifest so the PythonJob
+        # spec stays under Hail Batch's 1 MiB cap regardless of cohort size.
+        # See utils.write_manifest for the rationale.
+        manifest_path: cpg_utils.Path = get_output_path(
+            filename=f'manifests/{cohort.name}_manage_dragen_pipeline_manifest.json',
+            category='tmp',
+        )
+        write_manifest(
+            manifest_path=manifest_path,
+            payload={
+                'outputs': outputs,
+                'cram_ica_fids_path': cram_ica_fids_path,
+                'analysis_output_fids_path': analysis_output_fids_path,
+                'fastq_ids_path': fastq_ids_path,
+                'fastq_list_fid_and_filenames_path': fastq_list_fid_and_filenames_path,
+            },
+        )
+
         job: PythonJob = initialise_python_job(
             job_name=f'Manage Dragen pipeline runs for cohort: {cohort.name}',
             target=cohort,
             tool_name='Dragen',
         )
         job.image(image=get_driver_image())
+        job.spot(is_spot=False)
 
         job.call(
             manage_dragen_pipeline.run,
             cohort=cohort,
-            outputs=outputs,
-            cram_ica_fids_path=cram_ica_fids_path,
-            fastq_ids_path=fastq_ids_path,
-            fastq_list_fid_and_filenames_path=fastq_list_fid_and_filenames_path,
-            analysis_output_fids_path=analysis_output_fids_path,
+            manifest_path=manifest_path,
         )
 
         return self.make_outputs(
@@ -407,18 +423,30 @@ class ManageDragenMlr(CohortStage):
             stage=ManageDragenPipeline,
         )
 
+        manifest_path: cpg_utils.Path = get_output_path(
+            filename=f'manifests/{cohort.name}_manage_dragen_mlr_manifest.json',
+            category='tmp',
+        )
+        write_manifest(
+            manifest_path=manifest_path,
+            payload={
+                'outputs': outputs,
+                'pipeline_id_arguid_path_dict': pipeline_id_arguid_path_dict,
+            },
+        )
+
         job: PythonJob = initialise_python_job(
             job_name='MlrWithDragen',
             target=cohort,
             tool_name='ICA',
         )
         job.image(image=get_driver_image())
+        job.spot(is_spot=False)
 
         job.call(
             manage_dragen_mlr.run,
             cohort=cohort,
-            pipeline_id_arguid_path_dict=pipeline_id_arguid_path_dict,
-            outputs=outputs,
+            manifest_path=manifest_path,
         )
 
         return self.make_outputs(target=cohort, data=outputs, jobs=job)  # pyright: ignore[reportArgumentType]

--- a/src/dragen_align_pa/utils.py
+++ b/src/dragen_align_pa/utils.py
@@ -1,5 +1,7 @@
+import json
 import re
 import subprocess
+from collections.abc import Mapping
 from math import ceil
 from typing import TYPE_CHECKING, Any
 
@@ -92,6 +94,45 @@ def run_subprocess_with_log(
         logger.error(f'STDOUT: {e.stdout}')
         logger.error(f'STDERR: {e.stderr}')
         raise
+
+
+ManifestEntry = dict[str, cpg_utils.Path] | cpg_utils.Path | None
+
+
+def write_manifest(manifest_path: cpg_utils.Path, payload: Mapping[str, ManifestEntry]) -> None:
+    """Persist a flat dict of per-SG path dicts (and optional scalars) to JSON on GCS.
+
+    Hail Batch caps each PythonJob spec at 1 MiB and serializes path arguments
+    inline. With ~4N paths per cohort this overflowed at ~2.2k sequencing groups;
+    threading a single manifest path through job.call() instead keeps spec growth
+    O(1) regardless of cohort size.
+
+    Each top-level value must be one of: dict[str, Path], Path, or None — the
+    only shapes the dispatcher needs to pass through to a worker.
+    """
+
+    def _encode(v: ManifestEntry) -> Any:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return {k: str(p) for k, p in v.items()}
+        return str(v)
+
+    manifest_path.write_text(json.dumps({k: _encode(v) for k, v in payload.items()}))
+
+
+def load_manifest(manifest_path: cpg_utils.Path) -> dict[str, ManifestEntry]:
+    """Worker-side inverse of write_manifest()."""
+
+    def _decode(v: Any) -> ManifestEntry:
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return {k: cpg_utils.to_path(p) for k, p in v.items()}
+        return cpg_utils.to_path(v)
+
+    raw: dict[str, Any] = json.loads(manifest_path.read_text())
+    return {k: _decode(v) for k, v in raw.items()}
 
 
 def initialise_python_job(

--- a/src/dragen_align_pa/utils.py
+++ b/src/dragen_align_pa/utils.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 from collections.abc import Mapping
 from math import ceil
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import cpg_utils
 from cloudpathlib.exceptions import NoStatError
@@ -96,7 +96,7 @@ def run_subprocess_with_log(
         raise
 
 
-ManifestEntry = dict[str, cpg_utils.Path] | cpg_utils.Path | None
+ManifestEntry: TypeAlias = dict[str, cpg_utils.Path] | cpg_utils.Path | None
 
 
 def write_manifest(manifest_path: cpg_utils.Path, payload: Mapping[str, ManifestEntry]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Test config bootstrap.
+
+`dragen_align_pa.constants` reads `cpg_utils.config` at module-import time
+(`config_retrieve` for `[workflow][reads_type]` and
+`[ica.pipelines][dragen_version]`, plus `output_path` for the bucket root).
+To keep unit tests off GCS and free of a real cpg-utils config bundle, we
+install in-memory stand-ins on `cpg_utils.config` BEFORE any
+`dragen_align_pa.*` import happens — so when `constants.py` is loaded later
+it sees the stubs and its module-level reads succeed locally.
+"""
+
+import cpg_utils.config
+
+_ORIGINAL_CONFIG_RETRIEVE = cpg_utils.config.config_retrieve
+_ORIGINAL_OUTPUT_PATH = cpg_utils.config.output_path
+
+
+_TEST_CONFIG: dict[tuple, object] = {
+    ('workflow', 'reads_type'): 'cram',
+    ('ica', 'pipelines', 'dragen_version'): 'dragen_3_7_8',
+}
+
+
+def _test_config_retrieve(key, default=None):  # noqa: ANN001, ANN202
+    return _TEST_CONFIG.get(tuple(key), default)
+
+
+def _test_output_path(suffix: str = '', category: str | None = None) -> str:
+    del category
+    return f'gs://cpg-test-dataset-test/{suffix}'
+
+
+cpg_utils.config.config_retrieve = _test_config_retrieve  # type: ignore[assignment]
+cpg_utils.config.output_path = _test_output_path  # type: ignore[assignment]
+
+
+def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
+    cpg_utils.config.config_retrieve = _ORIGINAL_CONFIG_RETRIEVE  # type: ignore[assignment]
+    cpg_utils.config.output_path = _ORIGINAL_OUTPUT_PATH  # type: ignore[assignment]

--- a/tests/test_manage_dragen_manifest.py
+++ b/tests/test_manage_dragen_manifest.py
@@ -1,0 +1,83 @@
+"""Roundtrip tests for the dispatcher->worker manifest.
+
+ManageDragenPipeline and ManageDragenMlr previously passed every per-SG
+path dict inline through job.call(...), which embedded thousands of GS
+paths in the Hail Batch PythonJob spec and blew the 1 MiB cap at ~2.2k
+sequencing groups. The fix collapses those dicts into a single JSON
+manifest on GCS and threads only the manifest path through the spec.
+These tests pin the JSON schema so dispatcher and worker stay in sync
+for both stage shapes (pipeline cram+fastq, mlr).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import cpg_utils
+
+from dragen_align_pa.utils import load_manifest, write_manifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _path(s: str) -> cpg_utils.Path:
+    return cpg_utils.to_path(s)
+
+
+def test_pipeline_manifest_cram_mode_roundtrip(tmp_path: Path) -> None:
+    manifest_path = _path(str(tmp_path / 'manifest.json'))
+
+    payload = {
+        'outputs': {
+            'sg_a_success': _path('gs://b/p/sg_a_pipeline_success.json'),
+            'sg_a_pipeline_id_and_arguid': _path('gs://b/p/sg_a_pipeline_id_and_arguid.json'),
+            'cohort_errors': _path('gs://b/p/cohort_errors.log'),
+        },
+        'cram_ica_fids_path': {'sg_a': _path('gs://b/prep/sg_a_fids.json')},
+        'analysis_output_fids_path': {'sg_a': _path('gs://b/prep/sg_a_output_fid.json')},
+        'fastq_ids_path': None,
+        'fastq_list_fid_and_filenames_path': None,
+    }
+    write_manifest(manifest_path=manifest_path, payload=payload)
+
+    loaded = load_manifest(manifest_path)
+
+    assert loaded == payload
+
+
+def test_pipeline_manifest_fastq_mode_roundtrip(tmp_path: Path) -> None:
+    manifest_path = _path(str(tmp_path / 'manifest.json'))
+
+    payload = {
+        'outputs': {'cohort_errors': _path('gs://b/p/cohort_errors.log')},
+        'cram_ica_fids_path': None,
+        'analysis_output_fids_path': {'sg_a': _path('gs://b/prep/sg_a_output_fid.json')},
+        'fastq_ids_path': _path('gs://b/prep/cohort_fastq_ids.txt'),
+        'fastq_list_fid_and_filenames_path': {'sg_a': _path('gs://b/prep/sg_a_fastq_list_fid.json')},
+    }
+    write_manifest(manifest_path=manifest_path, payload=payload)
+
+    loaded = load_manifest(manifest_path)
+
+    assert loaded == payload
+
+
+def test_mlr_manifest_roundtrip(tmp_path: Path) -> None:
+    manifest_path = _path(str(tmp_path / 'manifest.json'))
+
+    payload = {
+        'outputs': {
+            'sg_a_mlr_success': _path('gs://b/p/sg_a_mlr_pipeline_success.json'),
+            'sg_a_mlr_pipeline_id': _path('gs://b/p/sg_a_mlr_pipeline_id.json'),
+            'cohort_mlr_errors': _path('gs://b/p/cohort_mlr_errors.log'),
+        },
+        'pipeline_id_arguid_path_dict': {
+            'sg_a_pipeline_id_and_arguid': _path('gs://b/p/sg_a_pipeline_id_and_arguid.json'),
+        },
+    }
+    write_manifest(manifest_path=manifest_path, payload=payload)
+
+    loaded = load_manifest(manifest_path)
+
+    assert loaded == payload


### PR DESCRIPTION
## Summary

`ManageDragenPipeline` and `ManageDragenMlr` pass per-SG path dicts (`outputs`, `cram_ica_fids_path`, `analysis_output_fids_path`, `pipeline_id_arguid_path_dict`, fastq variants) inline through `job.call(...)`. Hail Batch embeds path args inline in each PythonJob spec, which is capped at 1 MiB — the spec grows linearly with cohort size and overflows. The dispatcher now writes one flat JSON manifest to a tmp GCS path and threads only the manifest path through `job.call`; the worker reads it at runtime. Spec growth becomes O(1).

Also pins both jobs to non-preempt — preemption forces a full ICA poll restart and wastes hours of DRAGEN runtime. Matches `dragen-unified-dev` and the existing `UploadDataToIca` pattern.

cpg_flow's rerun-skip still consumes `expected_outputs()` at the dispatcher and is unaffected.

## Changes

- `src/dragen_align_pa/utils.py` — generic `write_manifest` / `load_manifest` + `ManifestEntry` type (`dict[str, Path] | Path | None`).
- `src/dragen_align_pa/stages.py` — both stage dispatchers write the manifest then call workers with only `manifest_path`; both gain `job.spot(is_spot=False)`.
- `src/dragen_align_pa/jobs/manage_dragen_pipeline.py`, `manage_dragen_mlr.py` — `run()` takes `manifest_path`; unpacks via `cast` at the boundary.
- `tests/test_manage_dragen_manifest.py` — pins the JSON schema for both stage shapes.
- `tests/conftest.py` — minimal `cpg_utils.config` stubs so the new tests can import `dragen_align_pa.constants`.
- `pyproject.toml` — `testpaths` typo (`test` → `tests`) so the new tests are discovered.

## Test plan

- [x] `pytest tests/` — 3 passed
- [x] `pytest --collect-only` — collects cleanly
- [x] `ruff check` + `ruff format --check` on changed files
- [x] `mypy` on changed files
- [ ] Dry-run a small cohort to confirm manifest is written and the worker reads it back