### PR TITLE
Make the DRAGEN CYP2D6 caller toggleable via config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.4.0
+ENV VERSION=3.4.1
 
 ARG ICA_CLI_VERSION="2.45.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.5.0
+ENV VERSION=3.5.1
 
 ARG ICA_CLI_VERSION="2.45.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.5.0
+## Pipeline Overview v3.5.1
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.4.0
+## Pipeline Overview v3.4.1
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -32,7 +32,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.5.0-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.5.1-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -10,6 +10,10 @@ skip_stages = ['DeleteDataInIca']
 # Can be fastq or CRAM, depending on the source of the reads for alignment
 reads_type = "fastq"
 
+# Set to false to skip the DRAGEN CYP2D6 pharmacogenomics caller.
+# Default true matches the historical pipeline configuration.
+enable_cyp2d6 = true
+
 # used to make sure we don't repeat previously completed stages
 check_expected_outputs = true
 

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -32,7 +32,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.4.0-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.4.1-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # # currently cpg-flow is pinned to this version.
 # # Keep [tool.ruff] target-version and [tool.mypy] python_version in sync with this.
 requires-python = ">=3.11,<3.12"
-version="3.5.0"
+version="3.5.1"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "3.5.0"
+current_version = "3.5.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # # currently cpg-flow is pinned to this version.
 # # Keep [tool.ruff] target-version and [tool.mypy] python_version in sync with this.
 requires-python = ">=3.11,<3.12"
-version="3.4.0"
+version="3.4.1"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "3.4.0"
+current_version = "3.4.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false

--- a/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
+++ b/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
@@ -164,6 +164,7 @@ def _build_cram_specific_inputs(
 
 def _build_common_parameters() -> list[AnalysisParameterInput]:
     """Builds the common ICA parameter inputs."""
+    enable_cyp2d6: bool = config_retrieve(['workflow', 'enable_cyp2d6'], default=True)
     return [
         AnalysisParameterInput(code='enable_map_align', value='true'),
         AnalysisParameterInput(code='enable_map_align_output', value='true'),
@@ -175,7 +176,7 @@ def _build_common_parameters() -> list[AnalysisParameterInput]:
         AnalysisParameterInput(code='enable_cnv', value='true'),
         AnalysisParameterInput(code='cnv_segmentation_mode', value='SLM'),
         AnalysisParameterInput(code='enable_sv', value='true'),
-        AnalysisParameterInput(code='enable_cyp2d6', value='true'),
+        AnalysisParameterInput(code='enable_cyp2d6', value='true' if enable_cyp2d6 else 'false'),
         AnalysisParameterInput(code='repeat_genotype_enable', value='true'),
         AnalysisParameterInput(code='dragen_reports', value='false'),
     ]

--- a/tests/test_enable_cyp2d6.py
+++ b/tests/test_enable_cyp2d6.py
@@ -1,0 +1,51 @@
+"""Verify enable_cyp2d6 is wired through config rather than hardcoded.
+
+The CYP2D6 caller adds non-trivial DRAGEN runtime — cohorts that don't
+need pharmacogenomics output (or that have hit unrelated CYP2D6-specific
+ICA bugs) need to be able to opt out without forking the source.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from dragen_align_pa.jobs import run_align_genotype_with_dragen
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _install_config(monkeypatch: pytest.MonkeyPatch, overrides: dict[tuple[str, ...], Any]) -> None:
+    def fake_config_retrieve(key, default=None):  # noqa: ANN001, ANN202
+        return overrides.get(tuple(key), default)
+
+    monkeypatch.setattr(run_align_genotype_with_dragen, 'config_retrieve', fake_config_retrieve)
+
+
+def _cyp2d6_value(params):  # noqa: ANN001, ANN202
+    [param] = [p for p in params if p['code'] == 'enable_cyp2d6']
+    return param['value']
+
+
+def test_enable_cyp2d6_defaults_to_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_config(monkeypatch, {})  # no override -> default kicks in
+
+    params = run_align_genotype_with_dragen._build_common_parameters()  # noqa: SLF001
+
+    assert _cyp2d6_value(params) == 'true'
+
+
+def test_enable_cyp2d6_can_be_disabled_via_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_config(monkeypatch, {('workflow', 'enable_cyp2d6'): False})
+
+    params = run_align_genotype_with_dragen._build_common_parameters()  # noqa: SLF001
+
+    assert _cyp2d6_value(params) == 'false'
+
+
+def test_enable_cyp2d6_respects_explicit_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_config(monkeypatch, {('workflow', 'enable_cyp2d6'): True})
+
+    params = run_align_genotype_with_dragen._build_common_parameters()  # noqa: SLF001
+
+    assert _cyp2d6_value(params) == 'true'


### PR DESCRIPTION
## Summary

The CYP2D6 caller was hardcoded on inside `_build_common_parameters` (`enable_cyp2d6 = 'true'`). This was because we thought that we would always run it. 
However, some samples could have a hom-deletion in CPY2D6, or otherwise poor coverage, and this would cause the pipeline to _always_ fail.
Now expose it via config, and default to `True` (enabled).

## Changes

- `src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py` — `_build_common_parameters` reads `enable_cyp2d6` from config (default `True`) and maps to the `'true'`/`'false'` string ICA expects.
- `config/dragen_align_pa_defaults.toml` — adds `enable_cyp2d6 = true` under `[workflow]` with a short comment.
- `tests/test_enable_cyp2d6.py` — covers default-on, explicit-on, and disabled-via-config.

## Test plan

- [x] `pytest tests/` — 6 passed (3 new + 3 existing)
- [x] `ruff check` + `ruff format --check`
- [x] `mypy`