### PR TITLE
Fix AR GUID preservation bug between the pipeline-id file and ICA userReference

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,29 +1,35 @@
-# name: Run Pytest
-# on:
-#   # Running on pull-requests and new pushes to main
-#   pull_request:
-#   push:
-#     branches:
-#       - main
+name: Run Pytest
+on:
+  # Running on pull-requests and new pushes to main
+  pull_request:
+  push:
+    branches:
+      - main
 
-# jobs:
-#   test:
-#     runs-on: ubuntu-latest
-#     defaults:
-#       run:
-#         shell: bash -l {0}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
 
-#     steps:
-#     - uses: actions/checkout@v4
+    steps:
+    - uses: actions/checkout@v5
 
-#     - uses: actions/setup-python@v4
-#       with:
-#         python-version: '3.11'
-#         cache: 'pip'
-#         cache-dependency-path: pyproject.toml
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+        cache-dependency-path: pyproject.toml
 
-#     - name: Install packages
-#       run: pip install .[test]
+    - name: Install icasdk
+      run: pip install git+https://github.com/Illumina/ica-sdk-python.git
 
-#     - name: Run pre-commit
-#       run: pytest test
+    - name: Install packages
+      run: pip install .[test]
+
+    - name: Pin typing-extensions (icasdk compat)
+      run: pip install typing-extensions==4.13.0
+
+    - name: Run tests
+      run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.4.0
+ENV VERSION=3.4.1
 
 ARG ICA_CLI_VERSION="2.45.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.4.1
+ENV VERSION=3.5.0
 
 ARG ICA_CLI_VERSION="2.45.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.4.1
+## Pipeline Overview v3.5.0
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.4.0
+## Pipeline Overview v3.4.1
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -28,7 +28,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.4.0-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.4.1-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -28,7 +28,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.4.1-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.5.0-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # # currently cpg-flow is pinned to this version.
 # # Keep [tool.ruff] target-version and [tool.mypy] python_version in sync with this.
 requires-python = ">=3.11,<3.12"
-version="3.4.1"
+version="3.5.0"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "3.4.1"
+current_version = "3.5.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # # currently cpg-flow is pinned to this version.
 # # Keep [tool.ruff] target-version and [tool.mypy] python_version in sync with this.
 requires-python = ">=3.11,<3.12"
-version="3.4.0"
+version="3.4.1"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "3.4.0"
+current_version = "3.4.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -5,6 +5,7 @@ wrappers around specific API endpoints.
 """
 
 import contextlib
+import functools
 import json
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Final, Literal
@@ -24,7 +25,6 @@ if TYPE_CHECKING:
 # --- Constants ---
 
 ICA_REST_ENDPOINT: Final = 'https://ica.illumina.com/ica/rest'
-SECRET_CLIENT: Final = secretmanager.SecretManagerServiceClient()
 SECRET_PROJECT: Final = 'cpg-common'
 SECRET_NAME: Final = 'illumina_cpg_workbench_api'
 SECRET_VERSION: Final = 'latest'
@@ -33,18 +33,25 @@ SECRET_VERSION: Final = 'latest'
 # --- Secret Management & Auth ---
 
 
+@functools.cache
+def _secret_client() -> secretmanager.SecretManagerServiceClient:
+    # Lazy so the module can be imported without GCP ADC (e.g. in CI test collection).
+    return secretmanager.SecretManagerServiceClient()
+
+
 def get_ica_secrets() -> dict[Literal['projectID', 'apiKey'], str]:
     """Gets the project ID and API key used to interact with ICA
 
     Returns:
         dict[str, str]: A dictionary with the keys projectId and apiKey
     """
-    secret_path: str = SECRET_CLIENT.secret_version_path(
+    client = _secret_client()
+    secret_path: str = client.secret_version_path(
         project=SECRET_PROJECT,
         secret=SECRET_NAME,
         secret_version=SECRET_VERSION,
     )
-    response: secretmanager.AccessSecretVersionResponse = SECRET_CLIENT.access_secret_version(
+    response: secretmanager.AccessSecretVersionResponse = client.access_secret_version(
         request={'name': secret_path},
     )
     return json.loads(response.payload.data.decode('UTF-8'))

--- a/src/dragen_align_pa/jobs/ica_pipeline_manager.py
+++ b/src/dragen_align_pa/jobs/ica_pipeline_manager.py
@@ -64,7 +64,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
     success_file_key_template: str,
     pipeline_id_file_key_template: str,
     error_log_key: str,
-    submit_function_factory: Callable[[str], Callable[[], str]],
+    submit_function_factory: Callable[[str, str], Callable[[], str]],
     allow_retry: bool,
     sleep_time_seconds: int,
 ) -> None:
@@ -119,30 +119,13 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
             ]
             pipeline_success_file: cpg_utils.Path = outputs[success_file_key_template.format(target_name=target_name)]
 
-            preserved_ar_guid_for_target: str = initial_ar_guid
-
             if pipeline_id_arguid_file.exists():
-                try:
-                    with pipeline_id_arguid_file.open('r') as f:
-                        data = json.load(f)
-                        if 'ar_guid' in data:
-                            preserved_ar_guid_for_target = data['ar_guid']
-                            logger.info(
-                                f"Preserved AR GUID '{preserved_ar_guid_for_target}' from existing file "
-                                f'for {target.name}.'
-                            )
-                except (json.JSONDecodeError, KeyError) as e:
-                    logger.warning(f'Could not read AR GUID from {pipeline_id_arguid_file}: {e}.')
-
                 pipeline_id_arguid_file.unlink()
                 logger.info(f'Deleted existing pipeline ID file: {pipeline_id_arguid_file}')
 
             if pipeline_success_file.exists():
                 pipeline_success_file.unlink()
                 logger.info(f'Deleted existing success file: {pipeline_success_file}')
-
-            # Set the ar_guid on the target object to be used for the new submission
-            target.ar_guid = preserved_ar_guid_for_target
 
     def is_finished(target: MonitoredTarget) -> bool:
         return target.status in {PipelineStatus.SUCCEEDED, PipelineStatus.CANCELLED, PipelineStatus.FAILED_FINAL}
@@ -173,13 +156,13 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                 delete_pipeline_id_file(pipeline_id_file=str(pipeline_id_arguid_file))
                 target.set_status(PipelineStatus.CANCELLED)
             else:
-                submit_callable: Callable[[], str] = submit_function_factory(target_name)
+                ar_guid_for_submit: str = target.ar_guid if target.ar_guid else initial_ar_guid
+                submit_callable: Callable[[], str] = submit_function_factory(target_name, ar_guid_for_submit)
 
                 if not target.pipeline_id:
                     logger.info(f'Submitting new {pipeline_name} ICA pipeline for {target_name}')
                     target.pipeline_id = submit_callable()
-                    # Use the preserved guid if it was set, otherwise use the initial one from the env
-                    target.ar_guid = target.ar_guid if target.ar_guid else initial_ar_guid
+                    target.ar_guid = ar_guid_for_submit
                     target.set_status(PipelineStatus.INPROGRESS)
                     with pipeline_id_arguid_file.open('w') as f:
                         f.write(json.dumps({'pipeline_id': target.pipeline_id, 'ar_guid': target.ar_guid}))
@@ -218,7 +201,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                     if target.allow_retry and not target.has_been_retried:
                         logger.info(f'Retrying {pipeline_name} pipeline for {target.name}')
                         target.pipeline_id = submit_callable()
-                        target.ar_guid = target.ar_guid if target.ar_guid else initial_ar_guid
+                        target.ar_guid = ar_guid_for_submit
                         target.has_been_retried = True
                         target.set_status(PipelineStatus.FAILED_RETRYING)
                         with pipeline_id_arguid_file.open('w') as f:

--- a/src/dragen_align_pa/jobs/manage_dragen_mlr.py
+++ b/src/dragen_align_pa/jobs/manage_dragen_mlr.py
@@ -204,8 +204,13 @@ def run(
 
     logger.info(f'Dataset name is: {cohort.dataset.name}')
 
-    def _create_submit_callable(sg_name: str) -> Callable[[], str]:
-        """Creates a zero-argument callable for pipeline submission."""
+    def _create_submit_callable(sg_name: str, ar_guid: str) -> Callable[[], str]:
+        """Creates a zero-argument callable for pipeline submission.
+
+        MLR reads ar_guid from the upstream Dragen pipeline-id file rather than
+        the env, so the manager-supplied ar_guid is intentionally ignored here.
+        """
+        del ar_guid
         output_prefix: str = (
             f'ica://{dragen_align_project}/{BUCKET_NAME}/'
             f'{config_retrieve(["ica", "data_prep", "output_folder"])}/{sg_name}'

--- a/src/dragen_align_pa/jobs/manage_dragen_pipeline.py
+++ b/src/dragen_align_pa/jobs/manage_dragen_pipeline.py
@@ -12,6 +12,7 @@ from dragen_align_pa.utils import load_manifest
 
 def _submit_new_ica_pipeline(
     sg_name: str,
+    ar_guid: str,
     cram_ica_fids_path: cpg_utils.Path | None,
     fastq_ids_path: cpg_utils.Path | None,
     fastq_list_fid_and_filenames_path: cpg_utils.Path | None,
@@ -23,6 +24,7 @@ def _submit_new_ica_pipeline(
         analysis_output_fid_path=analysis_output_fid_path,
         fastq_list_fid_and_filenames_path=fastq_list_fid_and_filenames_path,
         sg_name=sg_name,
+        ar_guid=ar_guid,
     )
     return ica_pipeline_id
 
@@ -46,11 +48,12 @@ def run(
         manifest['fastq_list_fid_and_filenames_path'],
     )
 
-    def _create_submit_callable(sg_name: str) -> Callable[[], str]:
+    def _create_submit_callable(sg_name: str, ar_guid: str) -> Callable[[], str]:
         """Creates a zero-argument callable for pipeline submission."""
         return partial(
             _submit_new_ica_pipeline,
             sg_name=sg_name,
+            ar_guid=ar_guid,
             cram_ica_fids_path=cram_ica_fids_path[sg_name] if cram_ica_fids_path else None,
             fastq_ids_path=fastq_ids_path,
             analysis_output_fid_path=analysis_output_fids_path[sg_name],

--- a/src/dragen_align_pa/jobs/manage_md5_pipeline.py
+++ b/src/dragen_align_pa/jobs/manage_md5_pipeline.py
@@ -214,8 +214,8 @@ def run(
         md5_outputs_folder_id=md5_outputs_folder_id,
     )
 
-    def _create_submit_callable_factory(target_name: str) -> Callable[[], str]:
-        _ = target_name
+    def _create_submit_callable_factory(target_name: str, ar_guid: str) -> Callable[[], str]:
+        del target_name, ar_guid  # MD5 binds its ar_guid eagerly above
         return submit_callable
 
     manage_ica_pipeline_loop(

--- a/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
+++ b/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 
 import cpg_utils
 import pandas as pd
-from cpg_utils.config import config_retrieve, try_get_ar_guid
+from cpg_utils.config import config_retrieve
 from icasdk.apis.tags import project_analysis_api
 from icasdk.model.analysis_data_input import AnalysisDataInput
 from icasdk.model.analysis_parameter_input import AnalysisParameterInput
@@ -189,6 +189,7 @@ def submit_dragen_run(
     ica_output_folder_id: str,
     api_instance: project_analysis_api.ProjectAnalysisApi,
     sg_name: str,
+    ar_guid: str,
 ) -> str:
     """Submit a Dragen alignment and genotyping run to ICA"""
     dragen_ht_id: str = config_retrieve(['ica', 'pipelines', 'dragen_ht_id'])
@@ -201,7 +202,7 @@ def submit_dragen_run(
     user_tags: list[str] = config_retrieve(['ica', 'tags', 'user_tags'])
     technical_tags: list[str] = config_retrieve(['ica', 'tags', 'technical_tags'])
     reference_tags: list[str] = config_retrieve(['ica', 'tags', 'reference_tags'])
-    user_reference: str = f'{sg_name}_{try_get_ar_guid()}_'
+    user_reference: str = f'{sg_name}_{ar_guid}_'
 
     logger.info(
         f'Loaded Dragen ICA configuration values, user reference: {user_reference}',
@@ -271,6 +272,7 @@ def run(
     fastq_ids_path: cpg_utils.Path | None,
     analysis_output_fid_path: cpg_utils.Path,
     sg_name: str,
+    ar_guid: str,
 ) -> str:
     """
     Main entrypoint for the PythonJob.
@@ -309,6 +311,7 @@ def run(
             project_id=path_params,
             api_instance=api_instance,
             sg_name=sg_name,
+            ar_guid=ar_guid,
         )
 
         logger.info(f'Submitted ICA run with pipeline ID: {analysis_run_id}')

--- a/tests/test_ica_pipeline_manager_ar_guid.py
+++ b/tests/test_ica_pipeline_manager_ar_guid.py
@@ -1,0 +1,211 @@
+"""Tests for AR GUID handling in manage_ica_pipeline_loop and submit_dragen_run.
+
+These pin two contracts:
+
+1. When ``force_resubmit`` is true, the loop must NOT preserve a stale AR GUID
+   from the existing pipeline-id file — it must use the fresh AR GUID from the
+   environment. (Otherwise downstream stages build the wrong ICA folder path.)
+2. The manager must pass the chosen AR GUID into the submit-callable factory,
+   and ``submit_dragen_run`` must use that AR GUID for the ICA ``userReference``
+   instead of independently calling ``try_get_ar_guid()``. (Otherwise the
+   AR GUID stored in the pipeline-id file can diverge from the one ICA uses
+   to name the run's output folder.)
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import cpg_utils
+
+from dragen_align_pa.jobs import ica_pipeline_manager, run_align_genotype_with_dragen
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    import pytest
+
+
+_SG_NAME = 'sg_a'
+_PIPELINE_ID_KEY = '{target_name}_pipeline_id_and_arguid'
+_SUCCESS_KEY = '{target_name}_success'
+_ERROR_KEY = 'cohort_errors'
+
+
+def _setup_outputs(tmp_path: Path) -> dict[str, cpg_utils.Path]:
+    return {
+        _PIPELINE_ID_KEY.format(target_name=_SG_NAME): cpg_utils.to_path(
+            str(tmp_path / f'{_SG_NAME}_pipeline_id_and_arguid.json'),
+        ),
+        _SUCCESS_KEY.format(target_name=_SG_NAME): cpg_utils.to_path(
+            str(tmp_path / f'{_SG_NAME}_pipeline_success.json'),
+        ),
+        _ERROR_KEY: cpg_utils.to_path(str(tmp_path / 'cohort_errors.log')),
+    }
+
+
+def _patch_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    force_resubmit: bool,
+    fresh_ar_guid: str,
+    monitor_status: str = 'SUCCEEDED',
+) -> None:
+    """Stub the manager's external dependencies for a single-iteration run."""
+
+    def fake_config_retrieve(key, default=None):  # noqa: ANN001, ANN202
+        key_tuple = tuple(key)
+        if key_tuple == ('ica', 'management', 'force_resubmit'):
+            return force_resubmit
+        if key_tuple == ('ica', 'management', 'cancel_cohort_run'):
+            return False
+        return default
+
+    monkeypatch.setattr(ica_pipeline_manager, 'config_retrieve', fake_config_retrieve)
+    monkeypatch.setattr(ica_pipeline_manager, 'try_get_ar_guid', lambda: fresh_ar_guid)
+    monkeypatch.setattr(
+        ica_pipeline_manager.monitor_dragen_pipeline,
+        'run',
+        lambda **_kwargs: monitor_status,
+    )
+    monkeypatch.setattr(ica_pipeline_manager.time, 'sleep', lambda *_a, **_kw: None)
+
+
+def test_force_resubmit_does_not_preserve_stale_ar_guid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pipeline-id file written after force_resubmit cleanup must contain
+    the fresh env AR GUID, not the stale one read from the previous file."""
+    monkeypatch.chdir(tmp_path)
+    outputs = _setup_outputs(tmp_path)
+
+    stale_pid_path = outputs[_PIPELINE_ID_KEY.format(target_name=_SG_NAME)]
+    with stale_pid_path.open('w') as fh:
+        json.dump({'pipeline_id': 'STALE-PID', 'ar_guid': 'STALE-GUID'}, fh)
+
+    _patch_manager(monkeypatch, force_resubmit=True, fresh_ar_guid='FRESH-GUID')
+
+    def factory(*_args: object, **_kwargs: object) -> Callable[[], str]:
+        # signature-agnostic so this test fails only on its own assertion
+        return lambda: f'NEW-PID-FOR-{_SG_NAME}'
+
+    ica_pipeline_manager.manage_ica_pipeline_loop(
+        targets_to_process=[SimpleNamespace(name=_SG_NAME)],
+        outputs=outputs,
+        pipeline_name='Dragen',
+        is_mlr_pipeline=False,
+        success_file_key_template=_SUCCESS_KEY,
+        pipeline_id_file_key_template=_PIPELINE_ID_KEY,
+        error_log_key=_ERROR_KEY,
+        submit_function_factory=factory,
+        allow_retry=False,
+        sleep_time_seconds=1,
+    )
+
+    written = json.loads(stale_pid_path.open().read())
+    assert written['ar_guid'] == 'FRESH-GUID', (
+        f"force_resubmit preserved the stale AR GUID; got {written['ar_guid']!r}"
+    )
+    assert written['pipeline_id'] == f'NEW-PID-FOR-{_SG_NAME}'
+
+
+def test_manager_passes_ar_guid_into_submit_factory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The manager invokes submit_function_factory with (sg_name, ar_guid)
+    so that the submitter can stamp the same AR GUID into ICA userReference."""
+    monkeypatch.chdir(tmp_path)
+    outputs = _setup_outputs(tmp_path)
+
+    _patch_manager(monkeypatch, force_resubmit=False, fresh_ar_guid='FRESH-GUID')
+
+    factory_calls: list[tuple[object, ...]] = []
+
+    def factory(*args: object) -> Callable[[], str]:
+        factory_calls.append(args)
+        return lambda: 'NEW-PID'
+
+    ica_pipeline_manager.manage_ica_pipeline_loop(
+        targets_to_process=[SimpleNamespace(name=_SG_NAME)],
+        outputs=outputs,
+        pipeline_name='Dragen',
+        is_mlr_pipeline=False,
+        success_file_key_template=_SUCCESS_KEY,
+        pipeline_id_file_key_template=_PIPELINE_ID_KEY,
+        error_log_key=_ERROR_KEY,
+        submit_function_factory=factory,
+        allow_retry=False,
+        sleep_time_seconds=1,
+    )
+
+    assert factory_calls == [(_SG_NAME, 'FRESH-GUID')]
+
+
+def test_submit_dragen_run_uses_ar_guid_argument_for_user_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """submit_dragen_run must build userReference from its ar_guid argument
+    rather than calling try_get_ar_guid() — otherwise the GUID in the
+    pipeline-id file and the GUID baked into the ICA folder name can diverge.
+    """
+    cram_ica_fids_path = cpg_utils.to_path(str(tmp_path / 'cram_fids.json'))
+    with cram_ica_fids_path.open('w') as fh:
+        json.dump({'cram_fid': 'cram-id-123'}, fh)
+
+    fake_config: dict[tuple, object] = {
+        ('ica', 'pipelines', 'dragen_ht_id'): 'ht_id',
+        ('ica', 'qc', 'cross_cont_vcf'): 'cc_id',
+        ('ica', 'qc', 'coverage_region_1'): 'cr1',
+        ('ica', 'qc', 'coverage_region_2'): 'cr2',
+        ('workflow', 'reads_type'): 'cram',
+        ('ica', 'pipelines', 'cram'): 'dragen_pid',
+        ('ica', 'tags', 'user_tags'): [],
+        ('ica', 'tags', 'technical_tags'): [],
+        ('ica', 'tags', 'reference_tags'): [],
+        ('ica', 'cram_references', 'old_cram_reference'): 'old_cram_key',
+        ('ica', 'cram_references', 'old_cram_key'): 'cram_ref_id',
+    }
+
+    def fake_config_retrieve(key, default=None):  # noqa: ANN001, ANN202
+        return fake_config.get(tuple(key), default)
+
+    monkeypatch.setattr(run_align_genotype_with_dragen, 'config_retrieve', fake_config_retrieve)
+    # If a future regression reintroduces try_get_ar_guid in this module, force it
+    # to a sentinel so the user_reference assertion would catch the divergence.
+    monkeypatch.setattr(
+        run_align_genotype_with_dragen,
+        'try_get_ar_guid',
+        lambda: 'ENV-GUID-MUST-NOT-BE-USED',
+        raising=False,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_submit_nextflow_analysis(*, api_instance, path_params, body, header_params):  # noqa: ANN001, ANN202, ARG001
+        captured['user_reference'] = body['userReference']
+        return 'fake-run-id'
+
+    monkeypatch.setattr(
+        run_align_genotype_with_dragen.ica_api_utils,
+        'submit_nextflow_analysis',
+        fake_submit_nextflow_analysis,
+    )
+
+    run_align_genotype_with_dragen.submit_dragen_run(
+        cram_ica_fids_path=cram_ica_fids_path,
+        fastq_ids_path=None,
+        fastq_list_fid_and_filenames_path=None,
+        project_id={'projectId': 'proj-id'},
+        ica_output_folder_id='folder-id',
+        api_instance=None,  # type: ignore[arg-type]
+        sg_name=_SG_NAME,
+        ar_guid='PASSED-IN-GUID',
+    )
+
+    assert captured['user_reference'] == f'{_SG_NAME}_PASSED-IN-GUID_'


### PR DESCRIPTION
## Summary

`force_resubmit` was preserving the stale AR GUID from the existing pipeline-id file, while `submit_dragen_run` independently called `try_get_ar_guid()` to build the ICA `userReference`. The two diverged, so the JSON stored one GUID and the actual ICA folder was named with another — every downstream stage (`download_specific_files_from_ica`, `download_md5_results`, `manage_dragen_mlr`) then 404s on a path that doesn't exist. This stamps the same AR GUID on both sides by construction. Also lifts the previously-commented-out CI workflow from `dragen-unified-dev` so pytest actually runs on PRs.

## Changes

- `src/dragen_align_pa/jobs/ica_pipeline_manager.py` — drop the read-and-preserve of the old `ar_guid` in the `force_resubmit` branch (just delete the stale files); change `submit_function_factory` contract to `(sg_name, ar_guid) -> Callable`, pick the AR GUID once per iteration and reuse it for both first-submit and retry so the dead `target.ar_guid or initial_ar_guid` fallback is gone.
- `src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py` — `submit_dragen_run` and `run` take an `ar_guid` parameter and build `userReference` from it instead of calling `try_get_ar_guid()`; drop the now-unused import.
- `src/dragen_align_pa/jobs/manage_dragen_pipeline.py` — thread `ar_guid` through `_submit_new_ica_pipeline` into `submit_dragen_run`.
- `src/dragen_align_pa/jobs/manage_dragen_mlr.py` — accept the new factory arg and explicitly discard it (MLR reads its `ar_guid` from the upstream Dragen pipeline-id file, not from the env).
- `src/dragen_align_pa/jobs/manage_md5_pipeline.py` — accept the new factory arg and discard it (MD5 binds its own `ar_guid` eagerly above the factory).
- `tests/test_ica_pipeline_manager_ar_guid.py` — pin all three contracts: `force_resubmit` must not preserve, the factory must receive `(sg_name, ar_guid)`, and `submit_dragen_run`'s `userReference` must come from its argument.
- `.github/workflows/test.yaml` — lifted from `dragen-unified-dev` so the test suite actually runs on PRs (the existing file was fully commented out).

## Test plan

- [x] `pytest` — 6 passed (3 new + 3 existing)
- [x] `ruff check` at pinned `v0.15.0` — clean on all touched files
- [x] `mypy` at pinned `v1.19.1` — clean on all touched files
- [x] CI passes on this PR