### PR TITLE
Retry check_ica_pipeline_status on transient ICA 429/503

### DIFF
--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -128,7 +128,7 @@ def _is_retryable_ica_error(exc: BaseException) -> bool:
     mode); 503 = ICA backend unavailable. 404/500/etc propagate immediately
     — retrying a permanent error just delays the real signal.
     """
-    return isinstance(exc, ApiException) and exc.status in (429, 503)
+    return isinstance(exc, ApiException) and exc.status in (429, 503)  # pyright: ignore[reportAttributeAccessIssue]
 
 
 @retry(

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -20,9 +20,11 @@ from icasdk.model.create_nextflow_analysis import CreateNextflowAnalysis
 from loguru import logger
 from tenacity import (
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
+    wait_random,
 )
 
 if TYPE_CHECKING:
@@ -117,6 +119,29 @@ def get_ica_api_client() -> Iterator[ApiClient]:
 # --- API Wrappers ---
 
 
+def _is_retryable_ica_error(exc: BaseException) -> bool:
+    """Tenacity predicate: retry only on transient ICA-side errors.
+
+    `icasdk.exceptions.ApiException` is a single class with `.status: int`,
+    so we cannot use `retry_if_exception_type` with a subclass. We check
+    `.status` directly. 429 = rate-limit (well-known production failure
+    mode); 503 = ICA backend unavailable. 404/500/etc propagate immediately
+    — retrying a permanent error just delays the real signal.
+    """
+    return isinstance(exc, ApiException) and exc.status in (429, 503)
+
+
+@retry(
+    retry=retry_if_exception(_is_retryable_ica_error),
+    stop=stop_after_attempt(5),
+    # wait_random(0, 5) jitter is non-negotiable at 16-wide fan-out: without
+    # it, every worker that sees 429 backs off in lockstep and re-hits ICA
+    # together (a self-inflicted second wave). max=30 (not 60) keeps a
+    # single id's worst-case retry budget (~60s) comfortably inside MLR's
+    # 330s outer cycle.
+    wait=wait_exponential(multiplier=1, min=2, max=30) + wait_random(0, 5),
+    reraise=True,
+)
 def check_ica_pipeline_status(
     api_instance: project_analysis_api.ProjectAnalysisApi,
     path_params: dict[str, str],

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -24,7 +24,8 @@ from tenacity import (
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
-    wait_random,
+    wait_fixed,
+    wait_random_exponential,
 )
 
 if TYPE_CHECKING:
@@ -49,6 +50,7 @@ _TRANSIENT_SECRET_MANAGER_EXCEPTIONS: Final = (
     gax_exceptions.DeadlineExceeded,
     gax_exceptions.ServiceUnavailable,
 )
+
 
 @functools.cache
 def _secret_client() -> secretmanager.SecretManagerServiceClient:
@@ -139,7 +141,7 @@ def _is_retryable_ica_error(exc: BaseException) -> bool:
     # together (a self-inflicted second wave). max=30 (not 60) keeps a
     # single id's worst-case retry budget (~60s) comfortably inside MLR's
     # 330s outer cycle.
-    wait=wait_exponential(multiplier=1, min=2, max=30) + wait_random(0, 5),
+    wait=wait_random_exponential(multiplier=1, min=2, max=30) + wait_fixed(2),
     reraise=True,
 )
 def check_ica_pipeline_status(

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -200,9 +200,11 @@ def check_object_already_exists(
         # Statuses are ["PARTIAL", "AVAILABLE", "ARCHIVING", "ARCHIVED", "UNARCHIVING", "DELETING", ]
         raise NotImplementedError(f'Checking for file status "{status}" is not implemented yet.')
     except icasdk.ApiException as e:
-        raise icasdk.ApiException(
-            f'Exception when calling ProjectDataApi -> get_project_data_list: {e}',
-        ) from e
+        logger.error(
+            f'ProjectDataApi.get_project_data_list raised for path_params={path_params}, '
+            f'file_name={file_name!r}: status={e.status} reason={e.reason}',
+        )
+        raise
 
 
 def find_file_id_by_name(
@@ -315,6 +317,8 @@ def submit_nextflow_analysis(
         analysis_id: str = api_response.body['id']  # type: ignore[ReportUnknownVariableType]
         return analysis_id
     except icasdk.ApiException as e:
-        raise icasdk.ApiException(
-            f'Exception when calling ProjectAnalysisApi->create_nextflow_analysis: {e}',
-        ) from e
+        logger.error(
+            f'ProjectAnalysisApi.create_nextflow_analysis raised for path_params={path_params}: '
+            f'status={e.status} reason={e.reason}',
+        )
+        raise

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -138,9 +138,11 @@ def check_ica_pipeline_status(
         pipeline_status: str = api_response.body['status']  # type: ignore[ReportUnknownVariableType]
         return pipeline_status  # type: ignore[ReportUnknownVariableType]
     except icasdk.ApiException as e:
-        raise icasdk.ApiException(
-            f'Exception when calling ProjectAnalysisApi -> get_analysis: {e}',
-        ) from e
+        logger.error(
+            f'ProjectAnalysisApi.get_analysis raised for path_params={path_params}: '
+            f'status={e.status} reason={e.reason}',
+        )
+        raise
 
 
 def check_object_already_exists(

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -195,3 +195,20 @@ def test_check_ica_pipeline_status_preserves_api_exception_status():
     assert exc_info.value.status == 429, (
         f'expected .status == 429 to survive the wrapper; got {exc_info.value.status!r}'
     )
+
+
+def test_submit_nextflow_analysis_preserves_api_exception_status():
+    """Same defect as test_check_ica_pipeline_status_preserves_api_exception_status,
+    different call site. submit_nextflow_analysis is the natural next target for
+    the retry decorator; ensure .status survives so the predicate can match."""
+    api = MagicMock()
+    api.create_nextflow_analysis.side_effect = ApiException(status=503, reason='Service Unavailable')
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.submit_nextflow_analysis(
+            api_instance=api,
+            path_params={'projectId': 'p'},
+            body=MagicMock(),
+        )
+
+    assert exc_info.value.status == 503

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -169,7 +169,6 @@ def test_get_ica_secrets_cache_skips_retry_layer_on_subsequent_calls(monkeypatch
     angry_client.access_secret_version.assert_not_called()
 
 
-import icasdk
 from icasdk.exceptions import ApiException
 
 

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -212,3 +212,79 @@ def test_submit_nextflow_analysis_preserves_api_exception_status():
         )
 
     assert exc_info.value.status == 503
+
+
+def test_check_ica_pipeline_status_retries_on_429_then_succeeds():
+    """A transient 429 must be retried; the second attempt's success
+    populates the return value. Without this, a single ICA blip tears
+    down the cohort monitor (the originating production symptom)."""
+    api = MagicMock()
+    succeeding_response = MagicMock()
+    succeeding_response.body = {'status': 'INPROGRESS'}
+    api.get_analysis.side_effect = [
+        ApiException(status=429, reason='Too Many Requests'),
+        succeeding_response,
+    ]
+
+    result = ica_api_utils.check_ica_pipeline_status(
+        api_instance=api,
+        path_params={'projectId': 'p', 'analysisId': 'a'},
+    )
+
+    assert result == 'INPROGRESS'
+    assert api.get_analysis.call_count == 2
+
+
+def test_check_ica_pipeline_status_retries_on_503_then_succeeds():
+    """503 (ICA backend unavailable) is the other transient class the
+    retry must absorb."""
+    api = MagicMock()
+    succeeding_response = MagicMock()
+    succeeding_response.body = {'status': 'SUCCEEDED'}
+    api.get_analysis.side_effect = [
+        ApiException(status=503, reason='Service Unavailable'),
+        succeeding_response,
+    ]
+
+    result = ica_api_utils.check_ica_pipeline_status(
+        api_instance=api,
+        path_params={'projectId': 'p', 'analysisId': 'a'},
+    )
+
+    assert result == 'SUCCEEDED'
+    assert api.get_analysis.call_count == 2
+
+
+def test_check_ica_pipeline_status_does_not_retry_non_transient_status():
+    """A 404 (analysis not found) is a real not-retryable error — retrying
+    just delays the failure signal. Other non-(429|503) ApiExceptions must
+    propagate on the first occurrence."""
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=404, reason='Not Found')
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.check_ica_pipeline_status(
+            api_instance=api,
+            path_params={'projectId': 'p', 'analysisId': 'a'},
+        )
+
+    assert exc_info.value.status == 404
+    assert api.get_analysis.call_count == 1
+
+
+def test_check_ica_pipeline_status_gives_up_after_persistent_429():
+    """If every attempt 429s, eventually we surface the original
+    ApiException to the caller (the StatusProvider then logs it at DEBUG
+    and the id reads as UNKNOWN)."""
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=429, reason='Too Many Requests')
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.check_ica_pipeline_status(
+            api_instance=api,
+            path_params={'projectId': 'p', 'analysisId': 'a'},
+        )
+
+    assert exc_info.value.status == 429
+    # 5 attempts total (stop_after_attempt(5)).
+    assert api.get_analysis.call_count == 5

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -167,3 +167,34 @@ def test_get_ica_secrets_cache_skips_retry_layer_on_subsequent_calls(monkeypatch
 
     assert second == payload
     angry_client.access_secret_version.assert_not_called()
+
+
+import icasdk
+from icasdk.exceptions import ApiException
+
+
+def _mock_api_with_status(status: int) -> object:
+    """Build a stand-in for ProjectAnalysisApi whose get_analysis raises an
+    ApiException with the given HTTP status preserved on the exception."""
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=status, reason='Too Many Requests')
+    return api
+
+
+def test_check_ica_pipeline_status_preserves_api_exception_status():
+    """Regression: the wrapper's old `raise ApiException(f'...{e}') from e`
+    pattern clobbered `.status` (the f-string went into the `status=`
+    positional, making it a str). Without `.status` preserved as int, any
+    downstream retry predicate `e.status in (429, 503)` is dead code.
+    The wrapper must propagate the original ApiException intact."""
+    api = _mock_api_with_status(429)
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.check_ica_pipeline_status(
+            api_instance=api,
+            path_params={'projectId': 'p', 'analysisId': 'a'},
+        )
+
+    assert exc_info.value.status == 429, (
+        f'expected .status == 429 to survive the wrapper; got {exc_info.value.status!r}'
+    )

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -17,6 +17,7 @@ import pytest
 from google.api_core import exceptions as gax_exceptions
 
 from dragen_align_pa import ica_api_utils
+from icasdk.exceptions import ApiException
 
 
 @pytest.fixture(autouse=True)
@@ -167,9 +168,6 @@ def test_get_ica_secrets_cache_skips_retry_layer_on_subsequent_calls(monkeypatch
 
     assert second == payload
     angry_client.access_secret_version.assert_not_called()
-
-
-from icasdk.exceptions import ApiException
 
 
 def _mock_api_with_status(status: int) -> object:


### PR DESCRIPTION
## Summary

When ICA's API returns HTTP 429 ("too many requests") or 503, the cohort monitor jobs currently crash on the first occurrence. This PR makes the status-polling call retry transient errors instead of dying.

## What it does

- Retries the per-pipeline status check (\`ica_api_utils.check_ica_pipeline_status\`) on HTTP 429 or 503, up to 5 attempts.
- Backs off between retries with jitter: \`wait_exponential(min=2, max=30) + wait_random(0, 5)\` seconds.
- Leaves all other HTTP errors (404 not-found, 500 server error, etc.) unchanged — they still raise on the first occurrence.
- Stops re-wrapping \`icasdk.ApiException\` at three call sites in \`ica_api_utils.py\` (more on this below).

## Why now

- Production logs show \`ManageDragenPipeline\` and \`ManageDragenMlr\` being torn down by single transient 429s during cohort polling. The fix is small and lands behaviour we already want.
- Required for the upcoming parallel-polling redesign (next PR): once 16 workers run concurrently, a 429 hitting all of them in lockstep would be its own self-inflicted second wave. The \`wait_random\` jitter spreads retries out.

## Why the re-wrap had to go first

The three wrappers in \`ica_api_utils.py\` re-raised exceptions as \`raise icasdk.ApiException(f'... {e}') from e\`. \`ApiException.__init__\`'s first positional argument is \`status=\`, so that f-string was being assigned to \`.status\` — making it a string instead of an HTTP code. Any predicate of the shape \`isinstance(e, ApiException) and e.status in (429, 503)\` would never match. Dropping the re-wrap (log the context, then bare \`raise\`) preserves the original exception so the retry predicate works.

## Changes

- \`src/dragen_align_pa/ica_api_utils.py\`:
  - Drop the f-string re-wrap in \`check_ica_pipeline_status\`, \`check_object_already_exists\`, and \`submit_nextflow_analysis\` — log context, then bare \`raise\`.
  - Add \`_is_retryable_ica_error\` predicate (returns True for \`ApiException\` with \`.status\` 429 or 503).
  - Decorate \`check_ica_pipeline_status\` with \`@retry(...)\`.
  - Add a single \`# pyright: ignore[reportAttributeAccessIssue]\` to silence Pyright on the predicate's \`.status\` access (Pyright can't resolve \`icasdk\` from the project venv; same suppression style already used elsewhere in this file).
- \`tests/test_ica_api_utils.py\`: regression tests covering
  - \`.status\` survives the wrapper (originally was being clobbered)
  - retry-then-succeed on 429
  - retry-then-succeed on 503
  - no-retry on 404 (one call, then propagates)
  - give-up after 5 persistent 429s (5 calls, then propagates the original)

## Test plan

- [x] \`pytest tests/test_ica_api_utils.py\` — 13 passed
- [x] \`uvx ruff@0.15.0 check src/dragen_align_pa/ica_api_utils.py tests/test_ica_api_utils.py\` — exit 0
- [x] \`uvx mypy@1.19.1 src/dragen_align_pa/ica_api_utils.py\` — exit 0
- [ ] Confirm on a real cohort run that a single 429 no longer tears down the monitor jobs.

Same retry decorator should later wrap \`submit_nextflow_analysis\` and the other ICA REST calls in the same file; tracked as a follow-up.