### PR TITLE
Bump reheader storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg2-1
 
 # Dragen align pa pipeline version.
-ENV VERSION=3.5.1
+ENV VERSION=3.5.2
 
 ARG ICA_CLI_VERSION="2.45.0"
 ARG SOMALIER_VERSION="0.3.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This pipeline aligns or realigns genomic sequencing data (from FASTQ or CRAM fil
 It manages data upload to ICA, submission and monitoring of the DRAGEN pipeline, and download of results (CRAMs, gVCFs, QC metrics) back to Google Cloud Storage (GCS). It also performs subsequent QC steps, including Somalier fingerprinting and MultiQC report generation.
 
 
-## Pipeline Overview v3.5.1
+## Pipeline Overview v3.5.2
 
 <div align="center">
     <img src="workflow_dag.svg" alt="Dragen Alignment Workflow DAG" width="80%"/>

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -32,7 +32,7 @@ sample_id = 'sample_id'
 [images]
 # This image contains the entire pipeline code. The version is automatically bumped by bump-my-version (or other version
 # incrememt tools), but you may need to change the final -1 suffix to the correct suffix.
-ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.5.1-1"
+ica = "australia-southeast1-docker.pkg.dev/cpg-common/images/dragen_align_pa:3.5.2-1"
 
 # Projects in ICA to run different analyses
 [ica.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # # currently cpg-flow is pinned to this version.
 # # Keep [tool.ruff] target-version and [tool.mypy] python_version in sync with this.
 requires-python = ">=3.11,<3.12"
-version="3.5.1"
+version="3.5.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ ignore = [
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
 [tool.bumpversion]
-current_version = "3.5.1"
+current_version = "3.5.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 allow_dirty = false

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from cpg_utils.config import image_path
+from cpg_utils.config import config_retrieve, image_path
 from cpg_utils.hail_batch import Batch, get_batch
 
 if TYPE_CHECKING:
@@ -22,7 +22,7 @@ def reheader_mlr_gvcf(
     b: Batch = get_batch()
     job: BashJob = b.new_bash_job(name='reheader_mlr_gvcf')
     job.image(image_path('bcftools', '1.23-2'))
-    job.storage(storage='16GB')
+    job.storage(storage=config_retrieve(['workflow', 'reheader_mlr_gvcf', 'storage'], '16GB'))
 
     gvcf_input_group = b.read_input_group(
         base_gvcf=str(base_gvcf_path),


### PR DESCRIPTION
# Purpose

  - Very occasionally, there is a gvcf that is very large, so reheadering it takes more space than the default allocation. Adding a config toggle to increase storage in these cases.