### PR TITLE
Parallel per-id ICA status provider + AR-GUID tag stamping

### DIFF
--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -179,3 +179,6 @@ coverage_region_beds = [
 config_json = "fil.91c3e63114fc43dc31ed08dde927d6b4"
 mlr_hash_table = "ica://ourdna-dragen-mlr-jobs/data/ref/hashtable/hg38_alt_masked_graph_v2/DRAGEN/9"
 analysis_instance_tier = "economy"
+
+[dragen_align_pa.reheader_mlr_gvcf]
+storage = "16GB"

--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -150,6 +150,16 @@ dragmap = 'fol.df2129db2c88419cbe0408dd600dce1f'
 # GATK reference FASTA
 gatk = ''
 
+# Parallel per-id status polling tuning (see ICA status-polling spec).
+# concurrency: ThreadPoolExecutor.max_workers per StatusProvider. Doubles as
+#   urllib3.PoolManager.connection_pool_maxsize on the shared ApiClient so
+#   the fan-out doesn't bottleneck at urllib3's default 4-sockets-per-host.
+# refresh_timeout_seconds: per-cycle wall-clock cap. Stranded futures are
+#   cancelled; their ids stay absent from the map and read as 'UNKNOWN'.
+[ica.polling]
+concurrency = 16
+refresh_timeout_seconds = 180
+
 [ica.qc]
 cross_cont_vcf = 'fil.1a7a2d0442854127e5d608da2935b1b0'
 # Legacy per-channel coverage region BED IDs. Read by run_align_genotype_with_dragen.py;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ exclude = '''
 python_version = "3.11"
 ignore_missing_imports = true
 
+[tool.pyright]
+pythonVersion = "3.11"
+
 [tool.pytest.ini_options]
 testpaths = ['tests']
 pythonpath = ['src']

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -8,6 +8,7 @@ import contextlib
 import functools
 import json
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import icasdk
@@ -360,3 +361,97 @@ def submit_nextflow_analysis(
             f'status={e.status} reason={e.reason}',
         )
         raise
+
+
+# --- Tag helpers ---
+
+
+@dataclass
+class _AnalysisTagBody:
+    """Lightweight stand-in for icasdk AnalysisTag for GET-modify-PUT writes.
+
+    icasdk's generated AnalysisTag is a DynamicSchema (dict-only access) and
+    the icasdk Analysis model requires 9 mandatory fields that are not needed
+    for a tags-only PUT. We use dataclasses to carry the three tag lists and
+    expose them as attributes so callers (and tests) can do body.tags.technicalTags.
+    """
+
+    technicalTags: list[str]  # noqa: N815
+    userTags: list[str]  # noqa: N815
+    referenceTags: list[str]  # noqa: N815
+
+
+@dataclass
+class _AnalysisUpdateBody:
+    """Minimal body for update_analysis (tags-only PUT).
+
+    icasdk's update_analysis endpoint accepts the request body as the Analysis
+    schema. In practice the ICA server merges/replaces only the fields supplied;
+    we send only the tags block. The dataclass avoids the icasdk model's 9-field
+    constructor requirement while still being JSON-serialisable by the api client.
+    """
+
+    tags: _AnalysisTagBody
+
+
+def add_technical_tag(
+    project_id: str,
+    analysis_id: str,
+    tag: str,
+) -> None:
+    """Append a tag to an analysis's technicalTags (idempotent / dedupe).
+
+    Used by the MLR submission path: popgen-cli does not stamp the
+    AR-GUID at submit time, so we GET the freshly-submitted analysis,
+    append the AR-GUID to technicalTags (deduped against whatever
+    popgen-cli wrote), and PUT the updated Analysis.
+
+    Best-effort: any failure (ApiException, missing tags block, ETag
+    drift) is logged at WARNING and swallowed. Correctness of the
+    polling design does not depend on the tag — it's a diagnostic
+    affordance for operators, not load-bearing state.
+
+    Note on the API shape: icasdk has no dedicated PATCH endpoint for
+    tags. The only mutator is PUT /api/projects/{projectId}/analyses/
+    {analysisId} (`update_analysis`), which is full-replace — hence
+    GET-modify-PUT.
+    """
+    try:
+        with get_ica_api_client() as api_client:
+            api_instance = project_analysis_api.ProjectAnalysisApi(api_client)
+            current = api_instance.get_analysis(
+                path_params={'projectId': project_id, 'analysisId': analysis_id},
+            )
+            current_tags = current.body.get('tags') or {}
+            existing = list(current_tags.get('technicalTags') or [])
+            if tag in existing:
+                logger.debug(f'tag {tag!r} already on analysis {analysis_id}; nothing to do')
+                return
+            existing.append(tag)
+            etag = current.headers.get('ETag') if hasattr(current, 'headers') else None
+            new_tags = _AnalysisTagBody(
+                technicalTags=existing,
+                userTags=list(current_tags.get('userTags') or []),
+                referenceTags=list(current_tags.get('referenceTags') or []),
+            )
+            new_body = _AnalysisUpdateBody(tags=new_tags)
+            header_params: dict[str, str] = {}
+            if etag:
+                header_params['If-Match'] = etag
+            api_instance.update_analysis(
+                path_params={'projectId': project_id, 'analysisId': analysis_id},
+                body=new_body,
+                header_params=header_params,
+            )
+            logger.info(f'Appended technical tag {tag!r} to analysis {analysis_id}')
+    except ApiException as e:
+        logger.warning(
+            f'add_technical_tag failed for analysis {analysis_id} '
+            f'(status={e.status}); continuing without the tag. '
+            f'Polling/cancel/delete do not depend on this tag.',
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            f'add_technical_tag failed for analysis {analysis_id}: {e}; '
+            f'continuing without the tag.',
+        )

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -11,6 +11,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import icasdk
+from cpg_utils.config import config_retrieve
 from google.api_core import exceptions as gax_exceptions
 from google.cloud import secretmanager
 from icasdk import ApiClient, Configuration
@@ -106,6 +107,16 @@ def get_ica_api_client() -> Iterator[ApiClient]:
 
     configuration = Configuration(host=ICA_REST_ENDPOINT)
     configuration.api_key['ApiKeyAuth'] = api_key
+    # urllib3 PoolManager defaults to maxsize=4 per host. At
+    # ParallelPerIdStatusProvider's max_workers=16, the unmodified default
+    # silently degrades the fan-out to ~4 in-flight (urllib3 logs
+    # "Connection pool is full, discarding connection") — wasting the
+    # parallelism. Drive from [ica.polling] concurrency so a single knob
+    # tunes both.
+    configuration.connection_pool_maxsize = config_retrieve(
+        ['ica', 'polling', 'concurrency'],
+        default=16,
+    )
 
     with ApiClient(configuration=configuration) as api_client:
         try:

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -7,8 +7,7 @@ wrappers around specific API endpoints.
 import contextlib
 import functools
 import json
-from collections.abc import Iterator
-from dataclasses import dataclass
+from collections.abc import Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import icasdk
@@ -40,6 +39,9 @@ ICA_REST_ENDPOINT: Final = 'https://ica.illumina.com/ica/rest'
 SECRET_PROJECT: Final = 'cpg-common'
 SECRET_NAME: Final = 'illumina_cpg_workbench_api'
 SECRET_VERSION: Final = 'latest'
+
+# HTTP 412 Precondition Failed — the If-Match ETag drifted between our GET and PUT.
+_HTTP_PRECONDITION_FAILED: Final = 412
 
 
 # --- Secret Management & Auth ---
@@ -366,32 +368,18 @@ def submit_nextflow_analysis(
 # --- Tag helpers ---
 
 
-@dataclass
-class _AnalysisTagBody:
-    """Lightweight stand-in for icasdk AnalysisTag for GET-modify-PUT writes.
+def _to_plain_json(obj: Any) -> Any:
+    """Recursively convert an icasdk schema instance to plain JSON types.
 
-    icasdk's generated AnalysisTag is a DynamicSchema (dict-only access) and
-    the icasdk Analysis model requires 9 mandatory fields that are not needed
-    for a tags-only PUT. We use dataclasses to carry the three tag lists and
-    expose them as attributes so callers (and tests) can do body.tags.technicalTags.
+    GET responses deserialize into immutable frozendict-backed schema
+    instances. To mutate one field and PUT it back we need a mutable copy
+    built from plain dict/list/scalar values.
     """
-
-    technicalTags: list[str]  # noqa: N815
-    userTags: list[str]  # noqa: N815
-    referenceTags: list[str]  # noqa: N815
-
-
-@dataclass
-class _AnalysisUpdateBody:
-    """Minimal body for update_analysis (tags-only PUT).
-
-    icasdk's update_analysis endpoint accepts the request body as the Analysis
-    schema. In practice the ICA server merges/replaces only the fields supplied;
-    we send only the tags block. The dataclass avoids the icasdk model's 9-field
-    constructor requirement while still being JSON-serialisable by the api client.
-    """
-
-    tags: _AnalysisTagBody
+    if isinstance(obj, Mapping):
+        return {key: _to_plain_json(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)) and not isinstance(obj, (str, bytes)):
+        return [_to_plain_json(item) for item in obj]
+    return obj
 
 
 def add_technical_tag(
@@ -404,46 +392,63 @@ def add_technical_tag(
     Used by the MLR submission path: popgen-cli does not stamp the
     AR-GUID at submit time, so we GET the freshly-submitted analysis,
     append the AR-GUID to technicalTags (deduped against whatever
-    popgen-cli wrote), and PUT the updated Analysis.
+    popgen-cli wrote), and PUT the updated Analysis back.
 
-    Best-effort: any failure (ApiException, missing tags block, ETag
-    drift) is logged at WARNING and swallowed. Correctness of the
-    polling design does not depend on the tag — it's a diagnostic
-    affordance for operators, not load-bearing state.
+    The PUT body must be the *complete* analysis object. icasdk's
+    `update_analysis` is a full-replace PUT whose request body validates
+    against the `Analysis` schema, and that schema has ten required
+    fields (id, pipeline, reference, status, ...). Sending only a tags
+    block — or a hand-rolled stand-in object — fails icasdk's local
+    serialization before any HTTP call is made. We therefore round-trip
+    the full object the GET returned, mutating only technicalTags.
 
-    Note on the API shape: icasdk has no dedicated PATCH endpoint for
-    tags. The only mutator is PUT /api/projects/{projectId}/analyses/
-    {analysisId} (`update_analysis`), which is full-replace — hence
-    GET-modify-PUT.
+    A single retry handles a 412 (If-Match ETag drift) from a concurrent
+    writer. Best-effort otherwise: any failure is logged at WARNING and
+    swallowed. Correctness of the polling design does not depend on the
+    tag — it's a diagnostic affordance for operators, not load-bearing
+    state.
     """
     try:
         with get_ica_api_client() as api_client:
             api_instance = project_analysis_api.ProjectAnalysisApi(api_client)
-            current = api_instance.get_analysis(
-                path_params={'projectId': project_id, 'analysisId': analysis_id},
-            )
-            current_tags = current.body.get('tags') or {}
-            existing = list(current_tags.get('technicalTags') or [])
-            if tag in existing:
-                logger.debug(f'tag {tag!r} already on analysis {analysis_id}; nothing to do')
+            for attempt in (1, 2):
+                current = api_instance.get_analysis(
+                    path_params={'projectId': project_id, 'analysisId': analysis_id},
+                )
+                body = _to_plain_json(current.body)
+                tags = body.get('tags')
+                if not isinstance(tags, dict):
+                    tags = {}
+                    body['tags'] = tags
+                existing: list[str] = list(tags.get('technicalTags') or [])
+                if tag in existing:
+                    logger.debug(
+                        f'tag {tag!r} already on analysis {analysis_id}; nothing to do',
+                    )
+                    return
+                existing.append(tag)
+                tags['technicalTags'] = existing
+
+                header_params: dict[str, str] = {}
+                etag = current.headers.get('ETag') if hasattr(current, 'headers') else None
+                if etag:
+                    header_params['If-Match'] = etag
+                try:
+                    api_instance.update_analysis(
+                        path_params={'projectId': project_id, 'analysisId': analysis_id},
+                        body=body,
+                        header_params=header_params,
+                    )
+                except ApiException as put_exc:
+                    if put_exc.status == _HTTP_PRECONDITION_FAILED and attempt == 1:
+                        logger.debug(
+                            f'update_analysis 412 (ETag drift) for {analysis_id}; '
+                            f're-reading and retrying once',
+                        )
+                        continue
+                    raise
+                logger.info(f'Appended technical tag {tag!r} to analysis {analysis_id}')
                 return
-            existing.append(tag)
-            etag = current.headers.get('ETag') if hasattr(current, 'headers') else None
-            new_tags = _AnalysisTagBody(
-                technicalTags=existing,
-                userTags=list(current_tags.get('userTags') or []),
-                referenceTags=list(current_tags.get('referenceTags') or []),
-            )
-            new_body = _AnalysisUpdateBody(tags=new_tags)
-            header_params: dict[str, str] = {}
-            if etag:
-                header_params['If-Match'] = etag
-            api_instance.update_analysis(
-                path_params={'projectId': project_id, 'analysisId': analysis_id},
-                body=new_body,
-                header_params=header_params,
-            )
-            logger.info(f'Appended technical tag {tag!r} to analysis {analysis_id}')
     except ApiException as e:
         logger.warning(
             f'add_technical_tag failed for analysis {analysis_id} '

--- a/src/dragen_align_pa/jobs/ica_pipeline_manager.py
+++ b/src/dragen_align_pa/jobs/ica_pipeline_manager.py
@@ -299,207 +299,212 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
         provider = status_provider
         owns_provider = False
 
-    while not all(is_finished(target) for target in monitored_targets):
-        # Pre-pass: hydrate pipeline IDs from disk for any target that doesn't
-        # have one yet. This must happen before the in_flight computation so
-        # that newly-resumed targets (whose pipeline_id file was written in a
-        # prior run) are included in the refresh batch on the very first cycle.
-        for t in monitored_targets:
-            if not is_finished(t) and not t.pipeline_id:
-                _pid_file = outputs[pipeline_id_file_key_template.format(target_name=t.name)]
-                if _pid_file.exists():
-                    with _pid_file.open('r') as _fh:
-                        _info = json.load(_fh)
-                        t.pipeline_id = _info['pipeline_id']
-                        t.ar_guid = _info['ar_guid']
-                        if t.status == PipelineStatus.PENDING:
-                            t.status = PipelineStatus.INPROGRESS
+    try:
+        while not all(is_finished(target) for target in monitored_targets):
+            # Pre-pass: hydrate pipeline IDs from disk for any target that doesn't
+            # have one yet. This must happen before the in_flight computation so
+            # that newly-resumed targets (whose pipeline_id file was written in a
+            # prior run) are included in the refresh batch on the very first cycle.
+            for t in monitored_targets:
+                if not is_finished(t) and not t.pipeline_id:
+                    _pid_file = outputs[pipeline_id_file_key_template.format(target_name=t.name)]
+                    if _pid_file.exists():
+                        with _pid_file.open('r') as _fh:
+                            _info = json.load(_fh)
+                            t.pipeline_id = _info['pipeline_id']
+                            t.ar_guid = _info['ar_guid']
+                            if t.status == PipelineStatus.PENDING:
+                                t.status = PipelineStatus.INPROGRESS
 
-        in_flight = {
-            t.pipeline_id
-            for t in monitored_targets
-            if t.pipeline_id and not is_finished(t)
-        }
-        provider.refresh(in_flight)
+            in_flight = {
+                t.pipeline_id
+                for t in monitored_targets
+                if t.pipeline_id and not is_finished(t)
+            }
+            provider.refresh(in_flight)
 
-        for target in monitored_targets:
-            if is_finished(target):
-                continue
-            target_name = target.name
-            pipeline_id_arguid_file = outputs[
-                pipeline_id_file_key_template.format(target_name=target_name)
-            ]
-
-            if pipeline_id_arguid_file.exists() and not target.pipeline_id:
-                with pipeline_id_arguid_file.open('r') as pipeline_fid_handle:
-                    pipeline_info = json.load(pipeline_fid_handle)
-                    target.pipeline_id = pipeline_info['pipeline_id']
-                    target.ar_guid = pipeline_info['ar_guid']
-                    # If we are loading the pipeline ID from file, we assume it is at least in progress
-                    if target.status == PipelineStatus.PENDING:
-                        target.status = PipelineStatus.INPROGRESS
-
-            # Cancel a pipeline if requested
-            if config_retrieve(key=['ica', 'management', 'cancel_cohort_run'], default=False) and target.pipeline_id:
-                logger.info(f'Cancelling {pipeline_name} pipeline run: {target.pipeline_id} for {target_name}')
-                # Match `_handle_management_flags`'s pre-loop cancel behaviour:
-                # if the ICA abort API fails, log it but still mark the target
-                # CANCELLED locally. User intent (cancel_cohort_run=true) takes
-                # precedence over the API result — without this catch, an ICA
-                # blip during cancel would propagate out of the loop as a
-                # generic exception, bypassing the orchestrator's CohortCancelled
-                # translation at the end of run().
-                try:
-                    cancel_ica_pipeline_run.run(
-                        ica_pipeline_id=target.pipeline_id,
-                        is_mlr=is_mlr_pipeline,
-                    )
-                except Exception as e:  # noqa: BLE001
-                    logger.error(
-                        f'ICA abort API call failed for {target_name} '
-                        f'(pipeline {target.pipeline_id}): {e}. '
-                        f'Marking CANCELLED locally anyway — user intent overrides the API result.',
-                    )
-                delete_pipeline_id_file(pipeline_id_file=str(pipeline_id_arguid_file))
-                target.set_status(PipelineStatus.CANCELLED)
-                _fire_status_change(target, PipelineStatus.CANCELLED)
-            else:
-                submit_callable: Callable[[], str] = submit_function_factory(target_name)
-
-                if not target.pipeline_id:
-                    logger.info(f'Submitting new {pipeline_name} ICA pipeline for {target_name}')
-                    target.pipeline_id = submit_callable()
-                    # Use the preserved guid if it was set, otherwise use the initial one from the env
-                    target.ar_guid = target.ar_guid if target.ar_guid else initial_ar_guid
-                    target.set_status(PipelineStatus.INPROGRESS)
-                    with pipeline_id_arguid_file.open('w') as f:
-                        f.write(json.dumps({'pipeline_id': target.pipeline_id, 'ar_guid': target.ar_guid}))
-
-                pipeline_status: str = provider.get_status(target.pipeline_id)
-
-                if pipeline_status == 'UNKNOWN':
-                    # No fresh status this cycle (worker failed or timed out);
-                    # leave the target's in-memory state untouched and retry
-                    # next cycle.
+            for target in monitored_targets:
+                if is_finished(target):
                     continue
-                if pipeline_status == 'INPROGRESS':
-                    target.set_status(new_status=PipelineStatus.INPROGRESS)
+                target_name = target.name
+                pipeline_id_arguid_file = outputs[
+                    pipeline_id_file_key_template.format(target_name=target_name)
+                ]
 
-                elif pipeline_status == 'SUCCEEDED':
-                    # Transactional SUCCEEDED transition: run the post-success callback
-                    # FIRST (e.g. fetch passfail.json + persist into the cohort batches
-                    # file). Only when it returns cleanly do we mark the target SUCCEEDED
-                    # and write the success marker. If the callback raises, leave state
-                    # as INPROGRESS so the next poll cycle re-fires it — this prevents
-                    # divergent state where the loop has set SUCCEEDED but the caller's
-                    # side-state (e.g. batches.json) was not updated.
-                    #
-                    # Capped at MAX_CONSECUTIVE_ON_SUCCEEDED_FAILURES per target: a
-                    # persistently failing callback (e.g. permanent IAM error) escalates
-                    # to FAILED_FINAL rather than spinning the loop forever.
-                    if not _process_succeeded_transition(target, on_succeeded, on_status_change):
-                        continue
-                    target.set_status(new_status=PipelineStatus.SUCCEEDED)
-                    logger.info(f'{pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}')
-                    pipeline_success_file = outputs[
-                        success_file_key_template.format(target_name=target_name)
-                    ]
-                    with pipeline_success_file.open('w') as success_file:
-                        success_file.write(
-                            f'ICA {pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}.'
+                if pipeline_id_arguid_file.exists() and not target.pipeline_id:
+                    with pipeline_id_arguid_file.open('r') as pipeline_fid_handle:
+                        pipeline_info = json.load(pipeline_fid_handle)
+                        target.pipeline_id = pipeline_info['pipeline_id']
+                        target.ar_guid = pipeline_info['ar_guid']
+                        # If we are loading the pipeline ID from file, we assume it is at least in progress
+                        if target.status == PipelineStatus.PENDING:
+                            target.status = PipelineStatus.INPROGRESS
+
+                # Cancel a pipeline if requested
+                cancel_requested = config_retrieve(key=['ica', 'management', 'cancel_cohort_run'], default=False)
+                if cancel_requested and target.pipeline_id:
+                    logger.info(f'Cancelling {pipeline_name} pipeline run: {target.pipeline_id} for {target_name}')
+                    # Match `_handle_management_flags`'s pre-loop cancel behaviour:
+                    # if the ICA abort API fails, log it but still mark the target
+                    # CANCELLED locally. User intent (cancel_cohort_run=true) takes
+                    # precedence over the API result — without this catch, an ICA
+                    # blip during cancel would propagate out of the loop as a
+                    # generic exception, bypassing the orchestrator's CohortCancelled
+                    # translation at the end of run().
+                    try:
+                        cancel_ica_pipeline_run.run(
+                            ica_pipeline_id=target.pipeline_id,
+                            is_mlr=is_mlr_pipeline,
                         )
-
-                elif pipeline_status in ['ABORTING', 'ABORTED']:
-                    logger.info(f'{pipeline_name} pipeline {target.pipeline_id} has been cancelled for {target_name}.')
-                    target.set_status(new_status=PipelineStatus.CANCELLED)
-                    target.pipeline_id = None
+                    except Exception as e:  # noqa: BLE001
+                        logger.error(
+                            f'ICA abort API call failed for {target_name} '
+                            f'(pipeline {target.pipeline_id}): {e}. '
+                            f'Marking CANCELLED locally anyway — user intent overrides the API result.',
+                        )
                     delete_pipeline_id_file(pipeline_id_file=str(pipeline_id_arguid_file))
+                    target.set_status(PipelineStatus.CANCELLED)
                     _fire_status_change(target, PipelineStatus.CANCELLED)
+                else:
+                    submit_callable: Callable[[], str] = submit_function_factory(target_name)
 
-                elif pipeline_status in ['FAILED', 'FAILEDFINAL']:
-                    logger.error(f'{pipeline_name} pipeline {target.pipeline_id} has failed for {target_name}.')
-                    delete_pipeline_id_file(pipeline_id_file=str(pipeline_id_arguid_file))
-                    target.pipeline_id = None
-
-                    # Determine if we should retry
-                    if target.allow_retry and not target.has_been_retried:
-                        logger.info(f'Retrying {pipeline_name} pipeline for {target.name}')
+                    if not target.pipeline_id:
+                        logger.info(f'Submitting new {pipeline_name} ICA pipeline for {target_name}')
                         target.pipeline_id = submit_callable()
+                        # Use the preserved guid if it was set, otherwise use the initial one from the env
                         target.ar_guid = target.ar_guid if target.ar_guid else initial_ar_guid
-                        target.has_been_retried = True
-                        target.set_status(PipelineStatus.FAILED_RETRYING)
+                        target.set_status(PipelineStatus.INPROGRESS)
                         with pipeline_id_arguid_file.open('w') as f:
                             f.write(json.dumps({'pipeline_id': target.pipeline_id, 'ar_guid': target.ar_guid}))
-                    else:
-                        target.set_status(PipelineStatus.FAILED_FINAL)
-                        _fire_status_change(target, PipelineStatus.FAILED_FINAL)
-                        logger.error(
-                            f'{target_name} failed {pipeline_name} pipeline {target.pipeline_id} and '
-                            f'retry is not allowed or already attempted.'
-                        )
 
-        status_counts: Counter[PipelineStatus] = Counter(target.status for target in monitored_targets)
-        if status_counts[PipelineStatus.CANCELLED] > 0:
-            cancelled_pipelines: list[str] = [
-                target.name for target in monitored_targets if target.status == PipelineStatus.CANCELLED
-            ]
-            logger.warning(f'Cancelled {pipeline_name} pipelines: {", ".join(cancelled_pipelines)}')
-            if status_counts[PipelineStatus.FAILED_FINAL] > 0:
+                    pipeline_status: str = provider.get_status(target.pipeline_id)
+
+                    if pipeline_status == 'UNKNOWN':
+                        # No fresh status this cycle (worker failed or timed out);
+                        # leave the target's in-memory state untouched and retry
+                        # next cycle.
+                        continue
+                    if pipeline_status == 'INPROGRESS':
+                        target.set_status(new_status=PipelineStatus.INPROGRESS)
+
+                    elif pipeline_status == 'SUCCEEDED':
+                        # Transactional SUCCEEDED transition: run the post-success callback
+                        # FIRST (e.g. fetch passfail.json + persist into the cohort batches
+                        # file). Only when it returns cleanly do we mark the target SUCCEEDED
+                        # and write the success marker. If the callback raises, leave state
+                        # as INPROGRESS so the next poll cycle re-fires it — this prevents
+                        # divergent state where the loop has set SUCCEEDED but the caller's
+                        # side-state (e.g. batches.json) was not updated.
+                        #
+                        # Capped at MAX_CONSECUTIVE_ON_SUCCEEDED_FAILURES per target: a
+                        # persistently failing callback (e.g. permanent IAM error) escalates
+                        # to FAILED_FINAL rather than spinning the loop forever.
+                        if not _process_succeeded_transition(target, on_succeeded, on_status_change):
+                            continue
+                        target.set_status(new_status=PipelineStatus.SUCCEEDED)
+                        logger.info(f'{pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}')
+                        pipeline_success_file = outputs[
+                            success_file_key_template.format(target_name=target_name)
+                        ]
+                        with pipeline_success_file.open('w') as success_file:
+                            success_file.write(
+                                f'ICA {pipeline_name} pipeline {target.pipeline_id} has succeeded for {target_name}.'
+                            )
+
+                    elif pipeline_status in ['ABORTING', 'ABORTED']:
+                        logger.info(
+                            f'{pipeline_name} pipeline {target.pipeline_id} has been cancelled for {target_name}.'
+                        )
+                        target.set_status(new_status=PipelineStatus.CANCELLED)
+                        target.pipeline_id = None
+                        delete_pipeline_id_file(pipeline_id_file=str(pipeline_id_arguid_file))
+                        _fire_status_change(target, PipelineStatus.CANCELLED)
+
+                    elif pipeline_status in ['FAILED', 'FAILEDFINAL']:
+                        logger.error(f'{pipeline_name} pipeline {target.pipeline_id} has failed for {target_name}.')
+                        delete_pipeline_id_file(pipeline_id_file=str(pipeline_id_arguid_file))
+                        target.pipeline_id = None
+
+                        # Determine if we should retry
+                        if target.allow_retry and not target.has_been_retried:
+                            logger.info(f'Retrying {pipeline_name} pipeline for {target.name}')
+                            target.pipeline_id = submit_callable()
+                            target.ar_guid = target.ar_guid if target.ar_guid else initial_ar_guid
+                            target.has_been_retried = True
+                            target.set_status(PipelineStatus.FAILED_RETRYING)
+                            with pipeline_id_arguid_file.open('w') as f:
+                                f.write(json.dumps({'pipeline_id': target.pipeline_id, 'ar_guid': target.ar_guid}))
+                        else:
+                            target.set_status(PipelineStatus.FAILED_FINAL)
+                            _fire_status_change(target, PipelineStatus.FAILED_FINAL)
+                            logger.error(
+                                f'{target_name} failed {pipeline_name} pipeline {target.pipeline_id} and '
+                                f'retry is not allowed or already attempted.'
+                            )
+
+            status_counts: Counter[PipelineStatus] = Counter(target.status for target in monitored_targets)
+            if status_counts[PipelineStatus.CANCELLED] > 0:
+                cancelled_pipelines: list[str] = [
+                    target.name for target in monitored_targets if target.status == PipelineStatus.CANCELLED
+                ]
+                logger.warning(f'Cancelled {pipeline_name} pipelines: {", ".join(cancelled_pipelines)}')
+                if status_counts[PipelineStatus.FAILED_FINAL] > 0:
+                    try:
+                        with open('tmp_errors.log') as tmp_log_handle:
+                            lines: list[str] = tmp_log_handle.readlines()
+                            with outputs[error_log_key].open('a') as gcp_error_log_file:
+                                gcp_error_log_file.write('\n'.join(lines))
+                    except (OSError, gcs_exceptions.GoogleCloudError) as e:
+                        logger.error(f'Error reading tmp_errors.log: {e}')
+                logger.info(
+                    f'{pipeline_name} pipeline status: '
+                    f'{status_counts[PipelineStatus.SUCCEEDED]} completed, '
+                    f'{status_counts[PipelineStatus.INPROGRESS]} in progress, '
+                    f'{status_counts[PipelineStatus.FAILED_FINAL]} failed, '
+                    f'{status_counts[PipelineStatus.CANCELLED]} cancelled. '
+                )
+                raise Exception(
+                    f'The following {pipeline_name} pipelines have been cancelled: {", ".join(cancelled_pipelines)}'
+                )
+
+            n_failed: int = status_counts[PipelineStatus.FAILED_FINAL]
+            if n_failed > 0 and float(n_failed) / float(total_targets) > 0.05:  # noqa: PLR2004
+                failed_pipelines: list[str] = [
+                    target.name for target in monitored_targets if target.status == PipelineStatus.FAILED_FINAL
+                ]
+                logger.error(
+                    f'More than 5% of {pipeline_name} pipelines have failed. '
+                    f'Failing pipelines: {" ".join(failed_pipelines)}'
+                )
                 try:
                     with open('tmp_errors.log') as tmp_log_handle:
-                        lines: list[str] = tmp_log_handle.readlines()
-                        with outputs[error_log_key].open('a') as gcp_error_log_file:
+                        lines = tmp_log_handle.readlines()
+                        with outputs[error_log_key].open('w') as gcp_error_log_file:
                             gcp_error_log_file.write('\n'.join(lines))
                 except (OSError, gcs_exceptions.GoogleCloudError) as e:
-                    logger.error(f'Error reading tmp_errors.log: {e}')
+                    logger.error(f'Failed to persist tmp_errors.log to {error_log_key} before 5% failure exit: {e}')
+                raise Exception(
+                    f'More than 5% of {pipeline_name} pipelines have failed. '
+                    f'Failing pipelines: {" ".join(failed_pipelines)}'
+                )
+            status_counts = Counter(target.status for target in monitored_targets)
             logger.info(
                 f'{pipeline_name} pipeline status: '
                 f'{status_counts[PipelineStatus.SUCCEEDED]} completed, '
                 f'{status_counts[PipelineStatus.INPROGRESS]} in progress, '
                 f'{status_counts[PipelineStatus.FAILED_FINAL]} failed, '
-                f'{status_counts[PipelineStatus.CANCELLED]} cancelled. '
+                f'{status_counts[PipelineStatus.CANCELLED]} cancelled.'
             )
-            raise Exception(
-                f'The following {pipeline_name} pipelines have been cancelled: {", ".join(cancelled_pipelines)}'
-            )
-
-        n_failed: int = status_counts[PipelineStatus.FAILED_FINAL]
-        if n_failed > 0 and float(n_failed) / float(total_targets) > 0.05:  # noqa: PLR2004
-            failed_pipelines: list[str] = [
-                target.name for target in monitored_targets if target.status == PipelineStatus.FAILED_FINAL
-            ]
-            logger.error(
-                f'More than 5% of {pipeline_name} pipelines have failed. '
-                f'Failing pipelines: {" ".join(failed_pipelines)}'
-            )
-            try:
-                with open('tmp_errors.log') as tmp_log_handle:
-                    lines = tmp_log_handle.readlines()
-                    with outputs[error_log_key].open('w') as gcp_error_log_file:
-                        gcp_error_log_file.write('\n'.join(lines))
-            except (OSError, gcs_exceptions.GoogleCloudError) as e:
-                logger.error(f'Failed to persist tmp_errors.log to {error_log_key} before 5% failure exit: {e}')
-            raise Exception(
-                f'More than 5% of {pipeline_name} pipelines have failed. '
-                f'Failing pipelines: {" ".join(failed_pipelines)}'
-            )
-        status_counts = Counter(target.status for target in monitored_targets)
-        logger.info(
-            f'{pipeline_name} pipeline status: '
-            f'{status_counts[PipelineStatus.SUCCEEDED]} completed, '
-            f'{status_counts[PipelineStatus.INPROGRESS]} in progress, '
-            f'{status_counts[PipelineStatus.FAILED_FINAL]} failed, '
-            f'{status_counts[PipelineStatus.CANCELLED]} cancelled.'
-        )
-        if all(is_finished(target) for target in monitored_targets):
-            break
-        time.sleep(sleep_time_seconds)
-
-    if owns_provider:
-        # close() is not on the StatusProvider Protocol surface — only on the
-        # concrete ParallelPerIdStatusProvider. Caller-injected providers may
-        # be other shapes; we only close our own default-constructed one.
-        provider.close()  # type: ignore[attr-defined]
+            if all(is_finished(target) for target in monitored_targets):
+                break
+            time.sleep(sleep_time_seconds)
+    finally:
+        if owns_provider:
+            # close() is not on the StatusProvider Protocol surface — only on
+            # the concrete ParallelPerIdStatusProvider. Caller-injected
+            # providers may be other shapes; we only close our own
+            # default-constructed one.
+            provider.close()  # type: ignore[attr-defined]
 
     try:
         with open('tmp_errors.log') as tmp_log_handle:

--- a/src/dragen_align_pa/jobs/ica_pipeline_manager.py
+++ b/src/dragen_align_pa/jobs/ica_pipeline_manager.py
@@ -280,21 +280,24 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                 f'Continuing — in-memory transition stands.',
             )
 
-    # The status_provider owns the parallel per-id fan-out across in-flight
-    # targets. Pass-through allows the orchestrator (or tests) to inject a
-    # fake; otherwise we instantiate one driven by [ica.polling] config.
-    owns_provider = status_provider is None
+    # Resolve the StatusProvider once into a non-Optional local binding so
+    # Pyright can narrow it across the loop body. If the caller passed one,
+    # they own its lifetime; otherwise we default-construct and close on exit.
     if status_provider is None:
         # MLR uses a different project than DRAGEN — caller can pass a
         # pre-configured provider with project_id set; the default path
         # reads from secrets in refresh() and falls back to the DRAGEN
         # project, which is correct for the DRAGEN call site.
-        status_provider = ParallelPerIdStatusProvider(
+        provider: StatusProvider = ParallelPerIdStatusProvider(
             concurrency=config_retrieve(['ica', 'polling', 'concurrency'], default=16),
             refresh_timeout_seconds=config_retrieve(
                 ['ica', 'polling', 'refresh_timeout_seconds'], default=180,
             ),
         )
+        owns_provider = True
+    else:
+        provider = status_provider
+        owns_provider = False
 
     while not all(is_finished(target) for target in monitored_targets):
         # Pre-pass: hydrate pipeline IDs from disk for any target that doesn't
@@ -317,7 +320,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
             for t in monitored_targets
             if t.pipeline_id and not is_finished(t)
         }
-        status_provider.refresh(in_flight)
+        provider.refresh(in_flight)
 
         for target in monitored_targets:
             if is_finished(target):
@@ -372,7 +375,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                     with pipeline_id_arguid_file.open('w') as f:
                         f.write(json.dumps({'pipeline_id': target.pipeline_id, 'ar_guid': target.ar_guid}))
 
-                pipeline_status: str = status_provider.get_status(target.pipeline_id)
+                pipeline_status: str = provider.get_status(target.pipeline_id)
 
                 if pipeline_status == 'UNKNOWN':
                     # No fresh status this cycle (worker failed or timed out);
@@ -493,8 +496,10 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
         time.sleep(sleep_time_seconds)
 
     if owns_provider:
-        # close() shuts down the ThreadPoolExecutor; idempotent + safe.
-        status_provider.close()  # type: ignore[union-attr,attr-defined]
+        # close() is not on the StatusProvider Protocol surface — only on the
+        # concrete ParallelPerIdStatusProvider. Caller-injected providers may
+        # be other shapes; we only close our own default-constructed one.
+        provider.close()  # type: ignore[attr-defined]
 
     try:
         with open('tmp_errors.log') as tmp_log_handle:

--- a/src/dragen_align_pa/jobs/ica_pipeline_manager.py
+++ b/src/dragen_align_pa/jobs/ica_pipeline_manager.py
@@ -20,7 +20,11 @@ from cpg_utils.config import config_retrieve, try_get_ar_guid
 from loguru import logger
 
 from dragen_align_pa.batches import IcaBatch
-from dragen_align_pa.jobs import cancel_ica_pipeline_run, monitor_dragen_pipeline
+from dragen_align_pa.jobs import cancel_ica_pipeline_run
+from dragen_align_pa.jobs.ica_status_provider import (
+    ParallelPerIdStatusProvider,
+    StatusProvider,
+)
 from dragen_align_pa.utils import delete_pipeline_id_file
 
 ProcessingTarget: TypeAlias = Cohort | SequencingGroup | IcaBatch
@@ -135,6 +139,7 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
     sleep_time_seconds: int,
     on_succeeded: Callable[[MonitoredTarget], None] | None = None,
     on_status_change: Callable[[MonitoredTarget, PipelineStatus], None] | None = None,
+    status_provider: StatusProvider | None = None,
 ) -> None:
     """
     Generic loop to manage ICA pipeline execution for a cohort.
@@ -275,7 +280,45 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                 f'Continuing — in-memory transition stands.',
             )
 
+    # The status_provider owns the parallel per-id fan-out across in-flight
+    # targets. Pass-through allows the orchestrator (or tests) to inject a
+    # fake; otherwise we instantiate one driven by [ica.polling] config.
+    owns_provider = status_provider is None
+    if status_provider is None:
+        # MLR uses a different project than DRAGEN — caller can pass a
+        # pre-configured provider with project_id set; the default path
+        # reads from secrets in refresh() and falls back to the DRAGEN
+        # project, which is correct for the DRAGEN call site.
+        status_provider = ParallelPerIdStatusProvider(
+            concurrency=config_retrieve(['ica', 'polling', 'concurrency'], default=16),
+            refresh_timeout_seconds=config_retrieve(
+                ['ica', 'polling', 'refresh_timeout_seconds'], default=180,
+            ),
+        )
+
     while not all(is_finished(target) for target in monitored_targets):
+        # Pre-pass: hydrate pipeline IDs from disk for any target that doesn't
+        # have one yet. This must happen before the in_flight computation so
+        # that newly-resumed targets (whose pipeline_id file was written in a
+        # prior run) are included in the refresh batch on the very first cycle.
+        for t in monitored_targets:
+            if not is_finished(t) and not t.pipeline_id:
+                _pid_file = outputs[pipeline_id_file_key_template.format(target_name=t.name)]
+                if _pid_file.exists():
+                    with _pid_file.open('r') as _fh:
+                        _info = json.load(_fh)
+                        t.pipeline_id = _info['pipeline_id']
+                        t.ar_guid = _info['ar_guid']
+                        if t.status == PipelineStatus.PENDING:
+                            t.status = PipelineStatus.INPROGRESS
+
+        in_flight = {
+            t.pipeline_id
+            for t in monitored_targets
+            if t.pipeline_id and not is_finished(t)
+        }
+        status_provider.refresh(in_flight)
+
         for target in monitored_targets:
             if is_finished(target):
                 continue
@@ -329,11 +372,13 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
                     with pipeline_id_arguid_file.open('w') as f:
                         f.write(json.dumps({'pipeline_id': target.pipeline_id, 'ar_guid': target.ar_guid}))
 
-                pipeline_status: str = monitor_dragen_pipeline.run(
-                    ica_pipeline_id=target.pipeline_id,
-                    is_mlr=is_mlr_pipeline,
-                )
+                pipeline_status: str = status_provider.get_status(target.pipeline_id)
 
+                if pipeline_status == 'UNKNOWN':
+                    # No fresh status this cycle (worker failed or timed out);
+                    # leave the target's in-memory state untouched and retry
+                    # next cycle.
+                    continue
                 if pipeline_status == 'INPROGRESS':
                     target.set_status(new_status=PipelineStatus.INPROGRESS)
 
@@ -446,6 +491,10 @@ def manage_ica_pipeline_loop(  # noqa: PLR0915
         if all(is_finished(target) for target in monitored_targets):
             break
         time.sleep(sleep_time_seconds)
+
+    if owns_provider:
+        # close() shuts down the ThreadPoolExecutor; idempotent + safe.
+        status_provider.close()  # type: ignore[union-attr,attr-defined]
 
     try:
         with open('tmp_errors.log') as tmp_log_handle:

--- a/src/dragen_align_pa/jobs/ica_status_provider.py
+++ b/src/dragen_align_pa/jobs/ica_status_provider.py
@@ -42,7 +42,7 @@ class ParallelPerIdStatusProvider:
     def __init__(
         self,
         concurrency: int,
-        refresh_timeout_seconds: int,
+        refresh_timeout_seconds: float,
         project_id: str | None = None,
     ) -> None:
         self._concurrency = concurrency

--- a/src/dragen_align_pa/jobs/ica_status_provider.py
+++ b/src/dragen_align_pa/jobs/ica_status_provider.py
@@ -70,7 +70,52 @@ class ParallelPerIdStatusProvider:
         Failures are absorbed and do not propagate. Affected ids stay
         absent from the map → get_status returns 'UNKNOWN'.
         """
-        raise NotImplementedError('Implemented in next task.')
+        self._status_map.clear()
+        if not in_flight_ids:
+            return
+
+        secrets = ica_api_utils.get_ica_secrets()
+        project_id = self._project_id or secrets['projectID']
+        t0 = time.monotonic()
+
+        with ica_api_utils.get_ica_api_client() as api_client:
+            api_instance = project_analysis_api.ProjectAnalysisApi(api_client)
+
+            def _fetch_one(pid: str) -> tuple[str, str]:
+                status = ica_api_utils.check_ica_pipeline_status(
+                    api_instance=api_instance,
+                    path_params={'projectId': project_id, 'analysisId': pid},
+                )
+                return pid, status
+
+            futures = {
+                self._executor.submit(_fetch_one, pid): pid
+                for pid in in_flight_ids
+            }
+            done, not_done = cf.wait(futures, timeout=self._refresh_timeout_s)
+            n_ok = 0
+            n_failed = 0
+            for fut in done:
+                pid = futures[fut]
+                try:
+                    _id, status = fut.result()
+                    self._status_map[pid] = status
+                    n_ok += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(f'status fetch failed for {pid}: {exc}')
+                    n_failed += 1
+            for fut in not_done:
+                fut.cancel()
+                n_failed += 1
+
+        elapsed = time.monotonic() - t0
+        if n_failed > 0:
+            ratio = n_failed / max(len(in_flight_ids), 1)
+            log = logger.error if ratio > 0.5 else logger.warning
+            log(
+                f'ica status refresh: n_ok={n_ok} n_failed={n_failed} '
+                f'elapsed={elapsed:.1f}s',
+            )
 
     def get_status(self, pipeline_id: str) -> str:
         """Return the most recently observed status, or 'UNKNOWN' if absent."""

--- a/src/dragen_align_pa/jobs/ica_status_provider.py
+++ b/src/dragen_align_pa/jobs/ica_status_provider.py
@@ -16,12 +16,15 @@ from __future__ import annotations
 
 import concurrent.futures as cf
 import time
-from typing import Protocol
+from typing import Protocol, Self
 
 from icasdk.apis.tags import project_analysis_api
 from loguru import logger
 
 from dragen_align_pa import ica_api_utils
+
+# ratio above which partial-fetch failure is escalated from WARNING to ERROR
+_ERROR_THRESHOLD = 0.5
 
 
 class StatusProvider(Protocol):
@@ -54,7 +57,7 @@ class ParallelPerIdStatusProvider:
             thread_name_prefix='ica-status',
         )
 
-    def __enter__(self) -> ParallelPerIdStatusProvider:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # noqa: ANN001
@@ -111,7 +114,7 @@ class ParallelPerIdStatusProvider:
         elapsed = time.monotonic() - t0
         if n_failed > 0:
             ratio = n_failed / max(len(in_flight_ids), 1)
-            log = logger.error if ratio > 0.5 else logger.warning
+            log = logger.error if ratio > _ERROR_THRESHOLD else logger.warning
             log(
                 f'ica status refresh: n_ok={n_ok} n_failed={n_failed} '
                 f'elapsed={elapsed:.1f}s',

--- a/src/dragen_align_pa/jobs/ica_status_provider.py
+++ b/src/dragen_align_pa/jobs/ica_status_provider.py
@@ -48,7 +48,6 @@ class ParallelPerIdStatusProvider:
         refresh_timeout_seconds: float,
         project_id: str | None = None,
     ) -> None:
-        self._concurrency = concurrency
         self._refresh_timeout_s = refresh_timeout_seconds
         self._project_id = project_id  # set by caller for MLR (different project)
         self._status_map: dict[str, str] = {}
@@ -108,6 +107,8 @@ class ParallelPerIdStatusProvider:
                     logger.debug(f'status fetch failed for {pid}: {exc}')
                     n_failed += 1
             for fut in not_done:
+                pid = futures[fut]
+                logger.debug(f'status fetch timed out for {pid}')
                 fut.cancel()
                 n_failed += 1
 

--- a/src/dragen_align_pa/jobs/ica_status_provider.py
+++ b/src/dragen_align_pa/jobs/ica_status_provider.py
@@ -1,0 +1,77 @@
+"""Per-cycle ICA pipeline-status fan-out for manage_ica_pipeline_loop.
+
+The provider holds a bounded ThreadPoolExecutor for its lifetime (one
+cohort run = hundreds of refresh cycles; recreating the executor per
+cycle wastes thread-spawn cost). On each refresh, it dispatches one
+`check_ica_pipeline_status` call per in-flight id. Successes populate
+an internal map; failures (tenacity exhaustion or cycle timeout) leave
+the id absent → reads as 'UNKNOWN' → existing elif chain in
+manage_ica_pipeline_loop falls through (no transition this cycle).
+
+NOT thread-safe: caller must serialise refresh()/get_status() (the
+polling loop is serial by design).
+"""
+
+from __future__ import annotations
+
+import concurrent.futures as cf
+import time
+from typing import Protocol
+
+from icasdk.apis.tags import project_analysis_api
+from loguru import logger
+
+from dragen_align_pa import ica_api_utils
+
+
+class StatusProvider(Protocol):
+    """The contract that manage_ica_pipeline_loop depends on."""
+
+    def refresh(self, in_flight_ids: set[str]) -> None: ...
+
+    def get_status(self, pipeline_id: str) -> str: ...
+
+
+class ParallelPerIdStatusProvider:
+    """Bounded-parallel per-id fan-out.
+
+    Lifetime is owned by the caller via `with` (the executor's threads
+    must shut down deterministically when the cohort run exits).
+    """
+
+    def __init__(
+        self,
+        concurrency: int,
+        refresh_timeout_seconds: int,
+        project_id: str | None = None,
+    ) -> None:
+        self._concurrency = concurrency
+        self._refresh_timeout_s = refresh_timeout_seconds
+        self._project_id = project_id  # set by caller for MLR (different project)
+        self._status_map: dict[str, str] = {}
+        self._executor = cf.ThreadPoolExecutor(
+            max_workers=concurrency,
+            thread_name_prefix='ica-status',
+        )
+
+    def __enter__(self) -> ParallelPerIdStatusProvider:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:  # noqa: ANN001
+        self.close()
+
+    def close(self) -> None:
+        """Shut down the executor, cancelling any pending futures."""
+        self._executor.shutdown(wait=True, cancel_futures=True)
+
+    def refresh(self, in_flight_ids: set[str]) -> None:
+        """Populate the status map for in_flight_ids via parallel fetches.
+
+        Failures are absorbed and do not propagate. Affected ids stay
+        absent from the map → get_status returns 'UNKNOWN'.
+        """
+        raise NotImplementedError('Implemented in next task.')
+
+    def get_status(self, pipeline_id: str) -> str:
+        """Return the most recently observed status, or 'UNKNOWN' if absent."""
+        return self._status_map.get(pipeline_id, 'UNKNOWN')

--- a/src/dragen_align_pa/jobs/manage_dragen_mlr.py
+++ b/src/dragen_align_pa/jobs/manage_dragen_mlr.py
@@ -13,6 +13,7 @@ from loguru import logger
 from dragen_align_pa import ica_cli_utils, utils
 from dragen_align_pa.constants import BUCKET_NAME
 from dragen_align_pa.jobs.ica_pipeline_manager import manage_ica_pipeline_loop
+from dragen_align_pa.jobs.ica_status_provider import ParallelPerIdStatusProvider
 from dragen_align_pa.utils import load_per_sg_state
 
 
@@ -213,15 +214,24 @@ def run(
             output_prefix=output_prefix,
         )
 
-    manage_ica_pipeline_loop(
-        targets_to_process=cohort.get_sequencing_groups(),
-        outputs=outputs,
-        pipeline_name='MLR',
-        is_mlr_pipeline=True,
-        success_file_key_template='{target_name}_mlr_success',
-        pipeline_id_file_key_template='{target_name}_mlr_pipeline_id',
-        error_log_key=f'{cohort.name}_mlr_errors',
-        submit_function_factory=_create_submit_callable,
-        allow_retry=False,
-        sleep_time_seconds=330,
-    )
+    mlr_project_id: str = config_retrieve(['ica', 'projects', 'dragen_mlr_project_id'])
+    with ParallelPerIdStatusProvider(
+        concurrency=config_retrieve(['ica', 'polling', 'concurrency'], default=16),
+        refresh_timeout_seconds=config_retrieve(
+            ['ica', 'polling', 'refresh_timeout_seconds'], default=180,
+        ),
+        project_id=mlr_project_id,
+    ) as status_provider:
+        manage_ica_pipeline_loop(
+            targets_to_process=cohort.get_sequencing_groups(),
+            outputs=outputs,
+            pipeline_name='MLR',
+            is_mlr_pipeline=True,
+            success_file_key_template='{target_name}_mlr_success',
+            pipeline_id_file_key_template='{target_name}_mlr_pipeline_id',
+            error_log_key=f'{cohort.name}_mlr_errors',
+            submit_function_factory=_create_submit_callable,
+            allow_retry=False,
+            sleep_time_seconds=330,
+            status_provider=status_provider,
+        )

--- a/src/dragen_align_pa/jobs/manage_dragen_mlr.py
+++ b/src/dragen_align_pa/jobs/manage_dragen_mlr.py
@@ -10,7 +10,7 @@ from cpg_flow.targets import Cohort
 from cpg_utils.config import config_retrieve
 from loguru import logger
 
-from dragen_align_pa import ica_cli_utils, utils
+from dragen_align_pa import ica_api_utils, ica_cli_utils, utils
 from dragen_align_pa.constants import BUCKET_NAME
 from dragen_align_pa.jobs.ica_pipeline_manager import manage_ica_pipeline_loop
 from dragen_align_pa.jobs.ica_status_provider import ParallelPerIdStatusProvider
@@ -127,6 +127,7 @@ def _submit_mlr_run(
     sg_name: str,
     cohort_name: str,
     mlr_project: str,
+    mlr_project_id: str,
     mlr_config_json: str,
     mlr_hash_table: str,
     output_prefix: str,
@@ -135,7 +136,10 @@ def _submit_mlr_run(
     Submits the DRAGEN MLR pipeline by running individual CLI commands
     and parsing the JSON output file.
     """
-    data = load_per_sg_state(pipeline_id_arguid_path, required_keys=('pipeline_id', 'user_reference'))
+    data = load_per_sg_state(
+        pipeline_id_arguid_path,
+        required_keys=('pipeline_id', 'user_reference', 'ar_guid'),
+    )
     pipeline_id = data['pipeline_id']
     user_reference = data['user_reference']
 
@@ -176,6 +180,17 @@ def _submit_mlr_run(
         mlr_analysis_id = _mlr_parse_submission_output(sg_name, mlr_run_id)
 
         logger.info(f'MLR pipeline ID for {sg_name} is {mlr_analysis_id}')
+
+        # Best-effort: stamp the AR-GUID into the MLR analysis's technicalTags so
+        # operators can filter the ICA UI by cohort run. popgen-cli has no tag
+        # flag, so this goes through icasdk's full-replace update_analysis
+        # (GET-modify-PUT). add_technical_tag swallows its own failures — no code
+        # path reads technicalTags for routing, so a missed tag is harmless.
+        ica_api_utils.add_technical_tag(
+            project_id=mlr_project_id,
+            analysis_id=mlr_analysis_id,
+            tag=data['ar_guid'],
+        )
         return mlr_analysis_id
 
     except (subprocess.CalledProcessError, FileNotFoundError, ValueError, json.JSONDecodeError) as e:
@@ -199,6 +214,7 @@ def run(
     mlr_config_json: str = config_retrieve(['dragen_align_pa', 'manage_dragen_mlr', 'config_json'])
     mlr_hash_table: str = config_retrieve(['dragen_align_pa', 'manage_dragen_mlr', 'mlr_hash_table'])
     output_prefix: str = f'ica://{dragen_align_project}/{BUCKET_NAME}/{ica_analysis_output_folder}'
+    mlr_project_id: str = config_retrieve(['ica', 'projects', 'dragen_mlr_project_id'])
 
     def _create_submit_callable(sg_name: str) -> Callable[[], str]:
         """Creates a zero-argument callable for pipeline submission."""
@@ -209,12 +225,12 @@ def run(
             sg_name=sg_name,
             cohort_name=cohort.name,
             mlr_project=mlr_project,
+            mlr_project_id=mlr_project_id,
             mlr_config_json=mlr_config_json,
             mlr_hash_table=mlr_hash_table,
             output_prefix=output_prefix,
         )
 
-    mlr_project_id: str = config_retrieve(['ica', 'projects', 'dragen_mlr_project_id'])
     with ParallelPerIdStatusProvider(
         concurrency=config_retrieve(['ica', 'polling', 'concurrency'], default=16),
         refresh_timeout_seconds=config_retrieve(

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -23,7 +23,7 @@ def reheader_mlr_gvcf(
     b: Batch = get_batch()
     job: BashJob = b.new_bash_job(name='reheader_mlr_gvcf')
     job.image(image_path('bcftools', '1.23-2'))
-    job.storage(storage=config_retrieve(['workflow', 'reheader_mlr_gvcf', 'storage'], default='16GB'))
+    job.storage(storage=config_retrieve(['dragen_align_pa', 'reheader_mlr_gvcf', 'storage'], default='16GB'))
 
     # Hail Batch's b.read_input_group / job.declare_resource_group return a
     # ResourceGroup at runtime, but the static return types resolve to the

--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from cpg_utils.config import image_path
+from cpg_utils.config import config_retrieve, image_path
 from cpg_utils.hail_batch import Batch, get_batch
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ def reheader_mlr_gvcf(
     b: Batch = get_batch()
     job: BashJob = b.new_bash_job(name='reheader_mlr_gvcf')
     job.image(image_path('bcftools', '1.23-2'))
-    job.storage(storage='16GB')
+    job.storage(storage=config_retrieve(['workflow', 'reheader_mlr_gvcf', 'storage'], default='16GB'))
 
     # Hail Batch's b.read_input_group / job.declare_resource_group return a
     # ResourceGroup at runtime, but the static return types resolve to the

--- a/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
+++ b/src/dragen_align_pa/jobs/run_align_genotype_with_dragen.py
@@ -199,9 +199,20 @@ def submit_dragen_run(
         ['ica', 'pipelines', config_retrieve(['workflow', 'reads_type'])],
     )
     user_tags: list[str] = config_retrieve(['ica', 'tags', 'user_tags'])
-    technical_tags: list[str] = config_retrieve(['ica', 'tags', 'technical_tags'])
     reference_tags: list[str] = config_retrieve(['ica', 'tags', 'reference_tags'])
-    user_reference: str = f'{sg_name}_{try_get_ar_guid()}_'
+    # AR-GUID must be present to form a meaningful user_reference; we don't
+    # support submission without one (matches submit_dragen_batch.py).
+    ar_guid = try_get_ar_guid()
+    if not ar_guid:
+        raise RuntimeError(
+            'try_get_ar_guid() returned None/empty — analysis-runner GUID is '
+            'missing from env. Refusing to submit.',
+        )
+    technical_tags: list[str] = [
+        *config_retrieve(['ica', 'tags', 'technical_tags']),
+        ar_guid,
+    ]
+    user_reference: str = f'{sg_name}_{ar_guid}_'
 
     logger.info(
         f'Loaded Dragen ICA configuration values, user reference: {user_reference}',

--- a/src/dragen_align_pa/jobs/submit_dragen_batch.py
+++ b/src/dragen_align_pa/jobs/submit_dragen_batch.py
@@ -43,8 +43,10 @@ _COMMON_ADDITIONAL_ARGS = (
     '--vc-gvcf-gq-bands 10 20 30 40 '
     '--vc-emit-ref-confidence GVCF '
     '--vc-enable-vcf-output false '
-    '--enable-map-align-output true '
-    '--enable-duplicate-marking true '
+    # NB: --enable-map-align-output and --enable-duplicate-marking are NOT set
+    # here. The DRAGEN pipeline XML emits both automatically when
+    # enable_map_align=true (always set as a top-level param); repeating them
+    # makes DRAGEN see each flag twice and hard-error, failing the batch.
     '--repeat-genotype-enable true '
 )
 

--- a/src/dragen_align_pa/jobs/submit_dragen_batch.py
+++ b/src/dragen_align_pa/jobs/submit_dragen_batch.py
@@ -515,7 +515,14 @@ def run(
 
     pipeline_id_config: str = config_retrieve(['dragen_align_pa', 'manage_dragen_pipeline', 'pipeline_id'])
     user_tags: list[str] = config_retrieve(['ica', 'tags', 'user_tags'])
-    technical_tags: list[str] = config_retrieve(['ica', 'tags', 'technical_tags'])
+    # AR-GUID is appended to technicalTags so operators can filter the ICA UI
+    # by cohort run (and so a future bulk-list polling strategy can scope its
+    # query). ar_guid is guaranteed non-empty by the try_get_ar_guid() guard
+    # above (line ~508).
+    technical_tags: list[str] = [
+        *config_retrieve(['ica', 'tags', 'technical_tags']),
+        ar_guid,
+    ]
     reference_tags: list[str] = config_retrieve(['ica', 'tags', 'reference_tags'])
 
     with ica_api_utils.get_ica_api_client() as api_client:

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -650,7 +650,13 @@ class SomalierExtract(SequencingGroupStage):
 
 
 @stage(
-    required_stages=[DownloadGvcfFromIca, DownloadMlrGvcfFromIca, SomalierExtract],
+    required_stages=[
+        DownloadGvcfFromIca,
+        DownloadMlrGvcfFromIca,
+        DownloadDataFromIca,
+        DownloadBatchArtefactsFromIca,
+        SomalierExtract,
+    ],
     analysis_type='gvcf',
     analysis_keys=['gvcf'],
 )

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -318,7 +318,8 @@ class ManageDragenPipeline(CohortStage):
             per_sg_fastq_list_paths = inputs.as_dict(target=cohort, stage=MakeFastqFileList)
 
         analysis_output_fid_path: cpg_utils.Path = inputs.as_path(
-            target=cohort, stage=PrepareIcaForDragenAnalysis,
+            target=cohort,
+            stage=PrepareIcaForDragenAnalysis,
         )
 
         job: PythonJob = initialise_python_job(
@@ -417,7 +418,10 @@ class DownloadCramFromIca(SequencingGroupStage):
             job_name='DownloadCramFromIca',
             sequencing_group=sequencing_group,
             file_spec=FileTypeSpec(
-                gcs_prefix='cram', data_suffix='cram', index_suffix='cram.crai', md5_suffix='md5sum',
+                gcs_prefix='cram',
+                data_suffix='cram',
+                index_suffix='cram.crai',
+                md5_suffix='md5sum',
             ),
             pipeline_id_arguid_path=pipeline_id_arguid_path,
             cohort_name=cohort.name,
@@ -645,7 +649,11 @@ class SomalierExtract(SequencingGroupStage):
         return self.make_outputs(sequencing_group, data=out_somalier_path, skipped=True)
 
 
-@stage(required_stages=[DownloadGvcfFromIca, DownloadMlrGvcfFromIca], analysis_type='gvcf', analysis_keys=['gvcf'])
+@stage(
+    required_stages=[DownloadGvcfFromIca, DownloadMlrGvcfFromIca, SomalierExtract],
+    analysis_type='gvcf',
+    analysis_keys=['gvcf'],
+)
 class ReheaderMlrGvcf(SequencingGroupStage):
     """
     Reheader the MLR gVCF to insert correct reference block information that the MLR process removes.
@@ -709,7 +717,8 @@ class DeleteDataInIca(CohortStage):
 
     def queue_jobs(self, cohort: Cohort, inputs: StageInput) -> StageOutput:
         cohort_analysis_output_fid_path: cpg_utils.Path = inputs.as_path(
-            target=cohort, stage=PrepareIcaForDragenAnalysis,
+            target=cohort,
+            stage=PrepareIcaForDragenAnalysis,
         )
 
         cram_fid_paths_dict: dict[str, cpg_utils.Path] | None = None
@@ -718,7 +727,9 @@ class DeleteDataInIca(CohortStage):
             cram_fid_paths_dict = inputs.as_path_by_target(stage=UploadDataToIca)
         elif READS_TYPE == 'fastq':
             fastq_ids_list_path = inputs.as_path(
-                target=cohort, stage=FastqIntakeQc, key='fastq_ids_outpath',
+                target=cohort,
+                stage=FastqIntakeQc,
+                key='fastq_ids_outpath',
             )
 
         output_path: cpg_utils.Path = self.expected_outputs(cohort=cohort)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,9 @@ _ORIGINAL_OUTPUT_PATH = cpg_utils.config.output_path
 
 _TEST_CONFIG: dict[tuple, object] = {
     ('workflow', 'reads_type'): 'cram',
-    # Match the production TOML value verbatim so any future test that doesn't
-    # explicitly monkeypatch DRAGEN_VERSION still gets a path-shape match.
     ('ica', 'pipelines', 'dragen_version'): 'dragen_3_7_8',
+    ('ica', 'polling', 'concurrency'): 16,
+    ('ica', 'polling', 'refresh_timeout_seconds'): 180,
 }
 
 

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -288,3 +288,34 @@ def test_check_ica_pipeline_status_gives_up_after_persistent_429():
     assert exc_info.value.status == 429
     # 5 attempts total (stop_after_attempt(5)).
     assert api.get_analysis.call_count == 5
+
+
+def test_get_ica_api_client_sets_connection_pool_maxsize(monkeypatch):
+    """urllib3.PoolManager defaults maxsize=4. At 16 workers, that
+    silently degrades the polling fan-out to ~4 in-flight. The context
+    manager must set connection_pool_maxsize from [ica.polling]
+    concurrency so the parallel polling design actually parallelises."""
+    captured: dict[str, object] = {}
+
+    class _FakeApiClient:
+        def __init__(self, configuration):
+            captured['pool_maxsize'] = configuration.connection_pool_maxsize
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+    monkeypatch.setattr('dragen_align_pa.ica_api_utils.ApiClient', _FakeApiClient)
+    monkeypatch.setattr(
+        ica_api_utils,
+        'get_ica_secrets',
+        lambda: {'projectID': 'p', 'apiKey': 'k'},
+    )
+
+    with ica_api_utils.get_ica_api_client():
+        pass
+
+    # Should match [ica.polling] concurrency from _TEST_CONFIG (16).
+    assert captured['pool_maxsize'] == 16

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -18,6 +18,10 @@ from google.api_core import exceptions as gax_exceptions
 
 from dragen_align_pa import ica_api_utils
 from icasdk.exceptions import ApiException
+from icasdk.model.analysis import Analysis
+from icasdk.paths.api_projects_project_id_analyses_analysis_id.put import (
+    request_body_analysis,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -321,26 +325,8 @@ def test_get_ica_api_client_sets_connection_pool_maxsize(monkeypatch):
     assert captured['pool_maxsize'] == 16
 
 
-def test_add_technical_tag_appends_and_dedupes(monkeypatch):
-    """The helper reads the current Analysis, appends the AR-GUID to
-    technicalTags (deduped), and PUTs the updated object. It MUST NOT
-    clobber tags written by popgen-cli."""
-    existing_get = MagicMock()
-    existing_get.body = {
-        'id': 'analysis-id',
-        'tags': {
-            'technicalTags': ['popgen-existing'],
-            'userTags': ['user-existing'],
-            'referenceTags': [],
-        },
-        'reference': 'existing-reference',
-    }
-    existing_get.headers = {'ETag': 'etag-abc'}
-
-    api = MagicMock()
-    api.get_analysis.return_value = existing_get
-    api.update_analysis.return_value = MagicMock(body={'id': 'analysis-id'})
-
+def _stub_ica_api(monkeypatch, api):
+    """Wire add_technical_tag to use a mock ProjectAnalysisApi."""
     monkeypatch.setattr(
         ica_api_utils,
         'get_ica_api_client',
@@ -353,6 +339,45 @@ def test_add_technical_tag_appends_and_dedupes(monkeypatch):
         'dragen_align_pa.ica_api_utils.project_analysis_api.ProjectAnalysisApi',
         lambda _client: api,
     )
+
+
+def _full_analysis_body() -> dict:
+    """A minimal-but-complete analysis as ICA's GET returns it.
+
+    `update_analysis` is a full-replace PUT whose body validates against
+    the `Analysis` schema (ten required fields), so the helper must PUT
+    the whole object back, not a tags-only fragment.
+    """
+    return {
+        'id': 'analysis-id',
+        'reference': 'existing-reference',
+        'userReference': 'uref',
+        'status': 'SUCCEEDED',
+        'tenantId': 'tenant-1',
+        'ownerId': 'owner-1',
+        'timeCreated': '2026-01-01T00:00:00Z',
+        'timeModified': '2026-01-01T00:00:00Z',
+        'pipeline': {'id': 'pipe-1', 'urn': 'urn:x'},
+        'tags': {
+            'technicalTags': ['popgen-existing'],
+            'userTags': ['user-existing'],
+            'referenceTags': [],
+        },
+    }
+
+
+def test_add_technical_tag_appends_and_dedupes(monkeypatch):
+    """The helper reads the current Analysis, appends the AR-GUID to
+    technicalTags (deduped), and PUTs the *complete* object back. It MUST
+    NOT clobber tags written by popgen-cli, nor drop other analysis fields."""
+    existing_get = MagicMock()
+    existing_get.body = _full_analysis_body()
+    existing_get.headers = {'ETag': 'etag-abc'}
+
+    api = MagicMock()
+    api.get_analysis.return_value = existing_get
+    api.update_analysis.return_value = MagicMock(body={'id': 'analysis-id'})
+    _stub_ica_api(monkeypatch, api)
 
     ica_api_utils.add_technical_tag(
         project_id='proj-1',
@@ -361,39 +386,96 @@ def test_add_technical_tag_appends_and_dedupes(monkeypatch):
     )
 
     update_kwargs = api.update_analysis.call_args.kwargs
-    assert 'AR-GUID-12345' in update_kwargs['body'].tags.technicalTags
-    assert 'popgen-existing' in update_kwargs['body'].tags.technicalTags
-    # No duplication if called twice — verify dedupe:
+    body = update_kwargs['body']
+    # Full object preserved (not a tags-only fragment).
+    assert body['id'] == 'analysis-id'
+    assert body['status'] == 'SUCCEEDED'
+    assert body['tags']['technicalTags'] == ['popgen-existing', 'AR-GUID-12345']
+    assert body['tags']['userTags'] == ['user-existing']
+    # If-Match carries the GET's ETag for optimistic concurrency.
+    assert update_kwargs['header_params'] == {'If-Match': 'etag-abc'}
+
+    # No duplication if the same tag is already present — verify dedupe:
+    existing_get.body = body  # second GET returns what we just PUT
     ica_api_utils.add_technical_tag(
         project_id='proj-1',
         analysis_id='analysis-id',
         tag='AR-GUID-12345',
     )
-    # Two calls total; the second body still has exactly one AR-GUID entry.
-    second_kwargs = api.update_analysis.call_args_list[1].kwargs
-    tags = second_kwargs['body'].tags.technicalTags
-    assert tags.count('AR-GUID-12345') == 1
+    # The tag is already present, so no second PUT happens.
+    assert api.update_analysis.call_count == 1
+
+
+def test_add_technical_tag_body_serializes_through_icasdk(monkeypatch):
+    """Regression guard for the original defect: the helper used a plain
+    dataclass body that failed icasdk's local serialization (Analysis needs
+    ten required fields) — every call was a swallowed no-op. Run the body
+    the helper builds through the real request-body serializer and assert
+    it produces a wire payload carrying the tag."""
+    valid_uuid = '12345678-1234-1234-1234-123456789abc'
+    ts = '2026-01-01T00:00:00Z'
+    analysis = Analysis(
+        id=valid_uuid, reference='ref', tenantId=valid_uuid, ownerId=valid_uuid,
+        timeCreated=ts, timeModified=ts, status='SUCCEEDED', userReference='uref',
+        pipeline={
+            'id': valid_uuid, 'urn': 'urn:x', 'timeCreated': ts, 'timeModified': ts,
+            'ownerId': valid_uuid, 'tenantId': valid_uuid, 'code': 'c',
+            'description': 'd', 'language': 'NEXTFLOW', 'pipelineTags': {'technicalTags': []},
+            'analysisStorage': {
+                'id': valid_uuid, 'timeCreated': ts, 'timeModified': ts,
+                'ownerId': valid_uuid, 'tenantId': valid_uuid, 'name': 'Small',
+                'description': 'd',
+            },
+        },
+        tags={'technicalTags': ['popgen'], 'userTags': [], 'referenceTags': []},
+    )
+    existing_get = MagicMock(body=analysis, headers={'ETag': 'e'})
+    api = MagicMock()
+    api.get_analysis.return_value = existing_get
+    api.update_analysis.return_value = MagicMock()
+    _stub_ica_api(monkeypatch, api)
+
+    ica_api_utils.add_technical_tag(
+        project_id='p', analysis_id='analysis-id', tag='AR-GUID-999',
+    )
+
+    sent_body = api.update_analysis.call_args.kwargs['body']
+    serialized = request_body_analysis.serialize(
+        sent_body, 'application/vnd.illumina.v3+json',
+    )
+    assert b'AR-GUID-999' in serialized['body']
+    assert b'popgen' in serialized['body']
+
+
+def test_add_technical_tag_retries_once_on_412(monkeypatch):
+    """A 412 (If-Match ETag drift) triggers a single re-read-and-retry."""
+    existing_get = MagicMock()
+    existing_get.body = _full_analysis_body()
+    existing_get.headers = {'ETag': 'etag-abc'}
+
+    api = MagicMock()
+    api.get_analysis.return_value = existing_get
+    api.update_analysis.side_effect = [
+        ApiException(status=412, reason='Precondition Failed'),
+        MagicMock(),
+    ]
+    _stub_ica_api(monkeypatch, api)
+
+    ica_api_utils.add_technical_tag(
+        project_id='proj-1', analysis_id='analysis-id', tag='AR-GUID-12345',
+    )
+
+    assert api.get_analysis.call_count == 2
+    assert api.update_analysis.call_count == 2
 
 
 def test_add_technical_tag_logs_and_swallows_on_persistent_failure(monkeypatch):
-    """Best-effort: on any ApiException after retry, log a warning and
-    return cleanly. Correctness of the polling design does not depend on
-    the tag, so a failed tag-write must not break MLR submission."""
+    """Best-effort: on any ApiException, log a warning and return cleanly.
+    Correctness of the polling design does not depend on the tag, so a
+    failed tag-write must not break MLR submission."""
     api = MagicMock()
     api.get_analysis.side_effect = ApiException(status=500, reason='Server Error')
-
-    monkeypatch.setattr(
-        ica_api_utils,
-        'get_ica_api_client',
-        lambda: MagicMock(
-            __enter__=MagicMock(return_value=MagicMock()),
-            __exit__=MagicMock(return_value=None),
-        ),
-    )
-    monkeypatch.setattr(
-        'dragen_align_pa.ica_api_utils.project_analysis_api.ProjectAnalysisApi',
-        lambda _client: api,
-    )
+    _stub_ica_api(monkeypatch, api)
 
     with patch('dragen_align_pa.ica_api_utils.logger') as mock_logger:
         # Must not raise.

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -11,7 +11,7 @@ why these blips propagate unhandled.
 """
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from google.api_core import exceptions as gax_exceptions
@@ -319,3 +319,87 @@ def test_get_ica_api_client_sets_connection_pool_maxsize(monkeypatch):
 
     # Should match [ica.polling] concurrency from _TEST_CONFIG (16).
     assert captured['pool_maxsize'] == 16
+
+
+def test_add_technical_tag_appends_and_dedupes(monkeypatch):
+    """The helper reads the current Analysis, appends the AR-GUID to
+    technicalTags (deduped), and PUTs the updated object. It MUST NOT
+    clobber tags written by popgen-cli."""
+    existing_get = MagicMock()
+    existing_get.body = {
+        'id': 'analysis-id',
+        'tags': {
+            'technicalTags': ['popgen-existing'],
+            'userTags': ['user-existing'],
+            'referenceTags': [],
+        },
+        'reference': 'existing-reference',
+    }
+    existing_get.headers = {'ETag': 'etag-abc'}
+
+    api = MagicMock()
+    api.get_analysis.return_value = existing_get
+    api.update_analysis.return_value = MagicMock(body={'id': 'analysis-id'})
+
+    monkeypatch.setattr(
+        ica_api_utils,
+        'get_ica_api_client',
+        lambda: MagicMock(
+            __enter__=MagicMock(return_value=MagicMock()),
+            __exit__=MagicMock(return_value=None),
+        ),
+    )
+    monkeypatch.setattr(
+        'dragen_align_pa.ica_api_utils.project_analysis_api.ProjectAnalysisApi',
+        lambda _client: api,
+    )
+
+    ica_api_utils.add_technical_tag(
+        project_id='proj-1',
+        analysis_id='analysis-id',
+        tag='AR-GUID-12345',
+    )
+
+    update_kwargs = api.update_analysis.call_args.kwargs
+    assert 'AR-GUID-12345' in update_kwargs['body'].tags.technicalTags
+    assert 'popgen-existing' in update_kwargs['body'].tags.technicalTags
+    # No duplication if called twice — verify dedupe:
+    ica_api_utils.add_technical_tag(
+        project_id='proj-1',
+        analysis_id='analysis-id',
+        tag='AR-GUID-12345',
+    )
+    # Two calls total; the second body still has exactly one AR-GUID entry.
+    second_kwargs = api.update_analysis.call_args_list[1].kwargs
+    tags = second_kwargs['body'].tags.technicalTags
+    assert tags.count('AR-GUID-12345') == 1
+
+
+def test_add_technical_tag_logs_and_swallows_on_persistent_failure(monkeypatch):
+    """Best-effort: on any ApiException after retry, log a warning and
+    return cleanly. Correctness of the polling design does not depend on
+    the tag, so a failed tag-write must not break MLR submission."""
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=500, reason='Server Error')
+
+    monkeypatch.setattr(
+        ica_api_utils,
+        'get_ica_api_client',
+        lambda: MagicMock(
+            __enter__=MagicMock(return_value=MagicMock()),
+            __exit__=MagicMock(return_value=None),
+        ),
+    )
+    monkeypatch.setattr(
+        'dragen_align_pa.ica_api_utils.project_analysis_api.ProjectAnalysisApi',
+        lambda _client: api,
+    )
+
+    with patch('dragen_align_pa.ica_api_utils.logger') as mock_logger:
+        # Must not raise.
+        ica_api_utils.add_technical_tag(
+            project_id='proj-1',
+            analysis_id='analysis-id',
+            tag='AR-GUID-12345',
+        )
+        assert mock_logger.warning.call_count >= 1

--- a/tests/test_ica_pipeline_manager.py
+++ b/tests/test_ica_pipeline_manager.py
@@ -6,12 +6,15 @@ in isolation; the SUCCEEDED-branch logic is extracted into a small helper
 exercised directly.
 """
 
+from unittest.mock import MagicMock
+
 from dragen_align_pa.batches import IcaBatch
 from dragen_align_pa.jobs.ica_pipeline_manager import (
     MAX_CONSECUTIVE_ON_SUCCEEDED_FAILURES,
     MonitoredTarget,
     PipelineStatus,
     _process_succeeded_transition,
+    manage_ica_pipeline_loop,
 )
 
 
@@ -118,3 +121,63 @@ def test_on_succeeded_swallows_status_change_callback_failure_during_escalation(
 def test_max_consecutive_on_succeeded_failures_constant_is_sane():
     """Sanity bound on the cap — must be > 0 and not absurd."""
     assert 1 <= MAX_CONSECUTIVE_ON_SUCCEEDED_FAILURES <= 20
+
+
+class _FakeStatusProvider:
+    """Records refresh calls and returns canned statuses."""
+
+    def __init__(self, status_by_id: dict[str, str]) -> None:
+        self.status_by_id = status_by_id
+        self.refresh_calls: list[set[str]] = []
+        self.get_status_calls: list[str] = []
+
+    def refresh(self, in_flight_ids):
+        self.refresh_calls.append(set(in_flight_ids))
+
+    def get_status(self, pipeline_id):
+        self.get_status_calls.append(pipeline_id)
+        return self.status_by_id.get(pipeline_id, 'UNKNOWN')
+
+
+def test_loop_reads_status_via_provider(tmp_path):
+    """manage_ica_pipeline_loop must call refresh(in_flight_ids) once per
+    cycle and get_status(target.pipeline_id) once per target — not
+    monitor_dragen_pipeline.run, which is the path being replaced."""
+    batch = IcaBatch(cohort_name='COH0001', batch_index=0, sg_names=['CPG_A'])
+    pipeline_id_file = tmp_path / 'COH0001-batch0000_pipeline_id.json'
+    success_file = tmp_path / 'COH0001-batch0000_success.json'
+    error_log = tmp_path / 'errors.log'
+
+    outputs = {
+        'COH0001-batch0000_pipeline_id': pipeline_id_file,
+        'COH0001-batch0000_success': success_file,
+        'COH0001_errors': error_log,
+    }
+
+    # Pre-seed the pipeline-id file so the loop skips its submission branch.
+    pipeline_id_file.write_text('{"pipeline_id": "analysis-XYZ", "ar_guid": "guid"}')
+
+    fake_provider = _FakeStatusProvider({'analysis-XYZ': 'SUCCEEDED'})
+
+    def factory(_target_name):
+        # The loop should NOT call this because pipeline_id is already on disk
+        # and the provider reports SUCCEEDED.
+        return MagicMock(return_value='analysis-XYZ')
+
+    manage_ica_pipeline_loop(
+        targets_to_process=[batch],
+        outputs=outputs,
+        pipeline_name='Dragen',
+        is_mlr_pipeline=False,
+        success_file_key_template='{target_name}_success',
+        pipeline_id_file_key_template='{target_name}_pipeline_id',
+        error_log_key='COH0001_errors',
+        submit_function_factory=factory,
+        allow_retry=False,
+        sleep_time_seconds=0,  # loop exits after one pass since SUCCEEDED is terminal
+        status_provider=fake_provider,
+    )
+
+    # refresh called once with the single in-flight id; get_status called for it.
+    assert fake_provider.refresh_calls == [{'analysis-XYZ'}]
+    assert fake_provider.get_status_calls == ['analysis-XYZ']

--- a/tests/test_ica_status_provider.py
+++ b/tests/test_ica_status_provider.py
@@ -116,3 +116,31 @@ def test_refresh_clears_stale_map_each_cycle():
             provider.refresh({'b'})  # 'a' is no longer in_flight
             assert provider.get_status('a') == 'UNKNOWN'
             assert provider.get_status('b') == 'INPROGRESS'
+
+
+def test_refresh_marks_timed_out_ids_as_unknown(monkeypatch):
+    """A worker hanging past refresh_timeout_seconds must not stall the
+    cycle. wait(timeout=...) returns the done set; stragglers are cancelled
+    (no-op if already running, but their absence from the map means
+    get_status returns 'UNKNOWN' → no transition this cycle, safe)."""
+    ica_api_utils_mod = __import__('dragen_align_pa.ica_api_utils', fromlist=['_'])
+    import time as time_module
+
+    def slow_check(api_instance, path_params):
+        if path_params['analysisId'] == 'slow':
+            time_module.sleep(2.0)  # hangs past the 0.1s cycle timeout
+        return 'INPROGRESS'
+
+    with patch.object(ica_api_utils_mod, 'check_ica_pipeline_status', side_effect=slow_check), \
+         patch.object(ica_api_utils_mod, 'get_ica_api_client',
+                      return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()),
+                                             __exit__=MagicMock(return_value=None))), \
+         patch.object(ica_api_utils_mod, 'get_ica_secrets',
+                      return_value={'projectID': 'proj', 'apiKey': 'k'}):
+        # Tiny timeout so the test runs in <1s.
+        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=0.1) as provider:
+            provider.refresh({'fast-1', 'fast-2', 'slow'})
+
+            assert provider.get_status('fast-1') == 'INPROGRESS'
+            assert provider.get_status('fast-2') == 'INPROGRESS'
+            assert provider.get_status('slow') == 'UNKNOWN'

--- a/tests/test_ica_status_provider.py
+++ b/tests/test_ica_status_provider.py
@@ -10,15 +10,32 @@ in test_ica_api_utils.py) so the focus stays on:
   - log-policy thresholds
 """
 
-import logging
+import time as time_module
 from unittest.mock import MagicMock, patch
 
-import pytest
+from icasdk.exceptions import ApiException
 
 from dragen_align_pa.jobs.ica_status_provider import (
     ParallelPerIdStatusProvider,
     StatusProvider,
 )
+
+_ICA_API_UTILS = __import__('dragen_align_pa.ica_api_utils', fromlist=['_'])
+
+_FAKE_API_CLIENT = MagicMock(
+    __enter__=MagicMock(return_value=MagicMock()),
+    __exit__=MagicMock(return_value=None),
+)
+_FAKE_SECRETS = {'projectID': 'proj', 'apiKey': 'k'}
+
+
+def _patch_ica(fake_check):
+    """Return a context manager that patches the three ica_api_utils callables."""
+    return (
+        patch.object(_ICA_API_UTILS, 'check_ica_pipeline_status', side_effect=fake_check),
+        patch.object(_ICA_API_UTILS, 'get_ica_api_client', return_value=_FAKE_API_CLIENT),
+        patch.object(_ICA_API_UTILS, 'get_ica_secrets', return_value=_FAKE_SECRETS),
+    )
 
 
 def test_status_provider_protocol_surface():
@@ -40,32 +57,17 @@ def test_refresh_populates_map_with_per_id_statuses():
     """Happy path: every in-flight id has its status fetched and stored."""
     statuses = {'a': 'INPROGRESS', 'b': 'SUCCEEDED', 'c': 'FAILED'}
 
-    def fake_check(api_instance, path_params):
+    def fake_check(api_instance, path_params):  # noqa: ARG001
         return statuses[path_params['analysisId']]
 
-    with patch.object(
-        ica_api_utils := __import__('dragen_align_pa.ica_api_utils', fromlist=['_']),
-        'check_ica_pipeline_status',
-        side_effect=fake_check,
-    ), patch.object(
-        ica_api_utils,
-        'get_ica_api_client',
-        return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=None)),
-    ), patch.object(
-        ica_api_utils,
-        'get_ica_secrets',
-        return_value={'projectID': 'proj', 'apiKey': 'k'},
-    ):
-        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
-            provider.refresh({'a', 'b', 'c'})
+    check_patch, client_patch, secrets_patch = _patch_ica(fake_check)
+    with check_patch, client_patch, secrets_patch, \
+            ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
+        provider.refresh({'a', 'b', 'c'})
 
-            assert provider.get_status('a') == 'INPROGRESS'
-            assert provider.get_status('b') == 'SUCCEEDED'
-            assert provider.get_status('c') == 'FAILED'
-
-
-import icasdk
-from icasdk.exceptions import ApiException
+        assert provider.get_status('a') == 'INPROGRESS'
+        assert provider.get_status('b') == 'SUCCEEDED'
+        assert provider.get_status('c') == 'FAILED'
 
 
 def test_refresh_marks_failed_ids_as_unknown_without_propagating():
@@ -73,77 +75,58 @@ def test_refresh_marks_failed_ids_as_unknown_without_propagating():
     inner wrapper, simulated here as a bare exception). refresh() must
     NOT propagate; affected ids stay absent → get_status returns 'UNKNOWN';
     successful ids still populate."""
-    def fake_check(api_instance, path_params):
+    def fake_check(api_instance, path_params):  # noqa: ARG001
         if path_params['analysisId'] == 'broken':
             raise ApiException(status=429, reason='Too Many Requests')
         return 'INPROGRESS'
 
-    ica_api_utils_mod = __import__('dragen_align_pa.ica_api_utils', fromlist=['_'])
+    check_patch, client_patch, secrets_patch = _patch_ica(fake_check)
+    with check_patch, client_patch, secrets_patch, \
+            ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
+        provider.refresh({'good-1', 'good-2', 'broken'})
 
-    with patch.object(ica_api_utils_mod, 'check_ica_pipeline_status', side_effect=fake_check), \
-         patch.object(ica_api_utils_mod, 'get_ica_api_client',
-                      return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()),
-                                             __exit__=MagicMock(return_value=None))), \
-         patch.object(ica_api_utils_mod, 'get_ica_secrets',
-                      return_value={'projectID': 'proj', 'apiKey': 'k'}):
-        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
-            provider.refresh({'good-1', 'good-2', 'broken'})
-
-            assert provider.get_status('good-1') == 'INPROGRESS'
-            assert provider.get_status('good-2') == 'INPROGRESS'
-            assert provider.get_status('broken') == 'UNKNOWN'
+        assert provider.get_status('good-1') == 'INPROGRESS'
+        assert provider.get_status('good-2') == 'INPROGRESS'
+        assert provider.get_status('broken') == 'UNKNOWN'
 
 
 def test_refresh_clears_stale_map_each_cycle():
     """Successive refresh() calls must not leak ids from a previous cycle —
     if an id transitions to terminal and is no longer in_flight, it must
     not still show as INPROGRESS from a stale cycle."""
-    ica_api_utils_mod = __import__('dragen_align_pa.ica_api_utils', fromlist=['_'])
-
-    def fake_check(api_instance, path_params):
+    def fake_check(api_instance, path_params):  # noqa: ARG001
         return 'INPROGRESS'
 
-    with patch.object(ica_api_utils_mod, 'check_ica_pipeline_status', side_effect=fake_check), \
-         patch.object(ica_api_utils_mod, 'get_ica_api_client',
-                      return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()),
-                                             __exit__=MagicMock(return_value=None))), \
-         patch.object(ica_api_utils_mod, 'get_ica_secrets',
-                      return_value={'projectID': 'proj', 'apiKey': 'k'}):
-        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
-            provider.refresh({'a', 'b'})
-            assert provider.get_status('a') == 'INPROGRESS'
+    check_patch, client_patch, secrets_patch = _patch_ica(fake_check)
+    with check_patch, client_patch, secrets_patch, \
+            ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
+        provider.refresh({'a', 'b'})
+        assert provider.get_status('a') == 'INPROGRESS'
 
-            provider.refresh({'b'})  # 'a' is no longer in_flight
-            assert provider.get_status('a') == 'UNKNOWN'
-            assert provider.get_status('b') == 'INPROGRESS'
+        provider.refresh({'b'})  # 'a' is no longer in_flight
+        assert provider.get_status('a') == 'UNKNOWN'
+        assert provider.get_status('b') == 'INPROGRESS'
 
 
-def test_refresh_marks_timed_out_ids_as_unknown(monkeypatch):
+def test_refresh_marks_timed_out_ids_as_unknown():
     """A worker hanging past refresh_timeout_seconds must not stall the
     cycle. wait(timeout=...) returns the done set; stragglers are cancelled
     (no-op if already running, but their absence from the map means
     get_status returns 'UNKNOWN' → no transition this cycle, safe)."""
-    ica_api_utils_mod = __import__('dragen_align_pa.ica_api_utils', fromlist=['_'])
-    import time as time_module
-
-    def slow_check(api_instance, path_params):
+    def slow_check(api_instance, path_params):  # noqa: ARG001
         if path_params['analysisId'] == 'slow':
             time_module.sleep(2.0)  # hangs past the 0.1s cycle timeout
         return 'INPROGRESS'
 
-    with patch.object(ica_api_utils_mod, 'check_ica_pipeline_status', side_effect=slow_check), \
-         patch.object(ica_api_utils_mod, 'get_ica_api_client',
-                      return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()),
-                                             __exit__=MagicMock(return_value=None))), \
-         patch.object(ica_api_utils_mod, 'get_ica_secrets',
-                      return_value={'projectID': 'proj', 'apiKey': 'k'}):
-        # Tiny timeout so the test runs in <1s.
-        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=0.1) as provider:
-            provider.refresh({'fast-1', 'fast-2', 'slow'})
+    check_patch, client_patch, secrets_patch = _patch_ica(slow_check)
+    # Tiny timeout so the test runs in <1s.
+    with check_patch, client_patch, secrets_patch, \
+            ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=0.1) as provider:
+        provider.refresh({'fast-1', 'fast-2', 'slow'})
 
-            assert provider.get_status('fast-1') == 'INPROGRESS'
-            assert provider.get_status('fast-2') == 'INPROGRESS'
-            assert provider.get_status('slow') == 'UNKNOWN'
+        assert provider.get_status('fast-1') == 'INPROGRESS'
+        assert provider.get_status('fast-2') == 'INPROGRESS'
+        assert provider.get_status('slow') == 'UNKNOWN'
 
 
 def test_close_shuts_down_the_executor():
@@ -157,3 +140,59 @@ def test_close_shuts_down_the_executor():
     provider.close()
 
     assert provider._executor._shutdown  # type: ignore[attr-defined]
+
+
+def test_refresh_logs_warning_when_some_failures():
+    """One summary log per refresh, level WARNING, only when n_failed > 0."""
+    def fake_check(api_instance, path_params):  # noqa: ARG001
+        if path_params['analysisId'].startswith('broken'):
+            raise ApiException(status=429, reason='Too Many Requests')
+        return 'INPROGRESS'
+
+    check_patch, client_patch, secrets_patch = _patch_ica(fake_check)
+    # 1 in 4 fails → ratio 0.25, well under 0.5 → WARNING (not ERROR).
+    with check_patch, client_patch, secrets_patch, \
+            ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider, \
+            patch('dragen_align_pa.jobs.ica_status_provider.logger') as mock_logger:
+        # loguru → caplog requires routing; easiest is asserting the map
+        # directly. We verify the summary log fires by patching logger.
+        provider.refresh({'good-1', 'good-2', 'good-3', 'broken-1'})
+
+        # WARNING (not ERROR) because failure ratio 0.25 ≤ 0.5.
+        assert mock_logger.warning.call_count == 1
+        assert mock_logger.error.call_count == 0
+        summary = mock_logger.warning.call_args.args[0]
+        assert 'n_ok=3' in summary
+        assert 'n_failed=1' in summary
+
+
+def test_refresh_does_not_log_when_all_succeed():
+    """No summary log when n_failed == 0 — 12K-target cycles would
+    otherwise flood the log every 600s."""
+    def fake_check(api_instance, path_params):  # noqa: ARG001
+        return 'INPROGRESS'
+
+    check_patch, client_patch, secrets_patch = _patch_ica(fake_check)
+    with check_patch, client_patch, secrets_patch, \
+            ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider, \
+            patch('dragen_align_pa.jobs.ica_status_provider.logger') as mock_logger:
+        provider.refresh({'a', 'b', 'c'})
+
+        assert mock_logger.warning.call_count == 0
+        assert mock_logger.error.call_count == 0
+
+
+def test_refresh_escalates_to_error_when_majority_failed():
+    """ratio > 0.5 ⇒ ERROR. Signals a cohort-wide ICA outage worth
+    paging on, not just a per-id flake."""
+    def fake_check(api_instance, path_params):  # noqa: ARG001
+        raise ApiException(status=503, reason='Service Unavailable')
+
+    check_patch, client_patch, secrets_patch = _patch_ica(fake_check)
+    with check_patch, client_patch, secrets_patch, \
+            ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider, \
+            patch('dragen_align_pa.jobs.ica_status_provider.logger') as mock_logger:
+        provider.refresh({'a', 'b', 'c'})
+
+        assert mock_logger.error.call_count == 1
+        assert mock_logger.warning.call_count == 0

--- a/tests/test_ica_status_provider.py
+++ b/tests/test_ica_status_provider.py
@@ -144,3 +144,16 @@ def test_refresh_marks_timed_out_ids_as_unknown(monkeypatch):
             assert provider.get_status('fast-1') == 'INPROGRESS'
             assert provider.get_status('fast-2') == 'INPROGRESS'
             assert provider.get_status('slow') == 'UNKNOWN'
+
+
+def test_close_shuts_down_the_executor():
+    """The provider's executor must shut down cleanly when the cohort run
+    exits (normal or exception path). The `with` block in
+    manage_ica_pipeline_loop relies on this so Hail Batch workers don't
+    leak threads."""
+    provider = ParallelPerIdStatusProvider(concurrency=2, refresh_timeout_seconds=10)
+    assert not provider._executor._shutdown  # type: ignore[attr-defined]
+
+    provider.close()
+
+    assert provider._executor._shutdown  # type: ignore[attr-defined]

--- a/tests/test_ica_status_provider.py
+++ b/tests/test_ica_status_provider.py
@@ -34,3 +34,31 @@ def test_parallel_per_id_status_provider_returns_unknown_before_first_refresh():
     the loop's elif chain falls through, no transition that cycle."""
     with ParallelPerIdStatusProvider(concurrency=2, refresh_timeout_seconds=10) as provider:
         assert provider.get_status('any-id') == 'UNKNOWN'
+
+
+def test_refresh_populates_map_with_per_id_statuses():
+    """Happy path: every in-flight id has its status fetched and stored."""
+    statuses = {'a': 'INPROGRESS', 'b': 'SUCCEEDED', 'c': 'FAILED'}
+
+    def fake_check(api_instance, path_params):
+        return statuses[path_params['analysisId']]
+
+    with patch.object(
+        ica_api_utils := __import__('dragen_align_pa.ica_api_utils', fromlist=['_']),
+        'check_ica_pipeline_status',
+        side_effect=fake_check,
+    ), patch.object(
+        ica_api_utils,
+        'get_ica_api_client',
+        return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=None)),
+    ), patch.object(
+        ica_api_utils,
+        'get_ica_secrets',
+        return_value={'projectID': 'proj', 'apiKey': 'k'},
+    ):
+        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
+            provider.refresh({'a', 'b', 'c'})
+
+            assert provider.get_status('a') == 'INPROGRESS'
+            assert provider.get_status('b') == 'SUCCEEDED'
+            assert provider.get_status('c') == 'FAILED'

--- a/tests/test_ica_status_provider.py
+++ b/tests/test_ica_status_provider.py
@@ -62,3 +62,57 @@ def test_refresh_populates_map_with_per_id_statuses():
             assert provider.get_status('a') == 'INPROGRESS'
             assert provider.get_status('b') == 'SUCCEEDED'
             assert provider.get_status('c') == 'FAILED'
+
+
+import icasdk
+from icasdk.exceptions import ApiException
+
+
+def test_refresh_marks_failed_ids_as_unknown_without_propagating():
+    """A subset of workers raises ApiException (exhausted retries from the
+    inner wrapper, simulated here as a bare exception). refresh() must
+    NOT propagate; affected ids stay absent → get_status returns 'UNKNOWN';
+    successful ids still populate."""
+    def fake_check(api_instance, path_params):
+        if path_params['analysisId'] == 'broken':
+            raise ApiException(status=429, reason='Too Many Requests')
+        return 'INPROGRESS'
+
+    ica_api_utils_mod = __import__('dragen_align_pa.ica_api_utils', fromlist=['_'])
+
+    with patch.object(ica_api_utils_mod, 'check_ica_pipeline_status', side_effect=fake_check), \
+         patch.object(ica_api_utils_mod, 'get_ica_api_client',
+                      return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()),
+                                             __exit__=MagicMock(return_value=None))), \
+         patch.object(ica_api_utils_mod, 'get_ica_secrets',
+                      return_value={'projectID': 'proj', 'apiKey': 'k'}):
+        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
+            provider.refresh({'good-1', 'good-2', 'broken'})
+
+            assert provider.get_status('good-1') == 'INPROGRESS'
+            assert provider.get_status('good-2') == 'INPROGRESS'
+            assert provider.get_status('broken') == 'UNKNOWN'
+
+
+def test_refresh_clears_stale_map_each_cycle():
+    """Successive refresh() calls must not leak ids from a previous cycle —
+    if an id transitions to terminal and is no longer in_flight, it must
+    not still show as INPROGRESS from a stale cycle."""
+    ica_api_utils_mod = __import__('dragen_align_pa.ica_api_utils', fromlist=['_'])
+
+    def fake_check(api_instance, path_params):
+        return 'INPROGRESS'
+
+    with patch.object(ica_api_utils_mod, 'check_ica_pipeline_status', side_effect=fake_check), \
+         patch.object(ica_api_utils_mod, 'get_ica_api_client',
+                      return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()),
+                                             __exit__=MagicMock(return_value=None))), \
+         patch.object(ica_api_utils_mod, 'get_ica_secrets',
+                      return_value={'projectID': 'proj', 'apiKey': 'k'}):
+        with ParallelPerIdStatusProvider(concurrency=4, refresh_timeout_seconds=10) as provider:
+            provider.refresh({'a', 'b'})
+            assert provider.get_status('a') == 'INPROGRESS'
+
+            provider.refresh({'b'})  # 'a' is no longer in_flight
+            assert provider.get_status('a') == 'UNKNOWN'
+            assert provider.get_status('b') == 'INPROGRESS'

--- a/tests/test_ica_status_provider.py
+++ b/tests/test_ica_status_provider.py
@@ -1,0 +1,36 @@
+"""Unit tests for the StatusProvider Protocol and ParallelPerIdStatusProvider.
+
+The provider runs the per-cycle ICA fan-out for `manage_ica_pipeline_loop`.
+These tests stub `check_ica_pipeline_status` (mocking the SDK is covered
+in test_ica_api_utils.py) so the focus stays on:
+  - map population on success
+  - partial-failure → 'UNKNOWN'
+  - cycle wall-clock timeout
+  - executor lifecycle
+  - log-policy thresholds
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dragen_align_pa.jobs.ica_status_provider import (
+    ParallelPerIdStatusProvider,
+    StatusProvider,
+)
+
+
+def test_status_provider_protocol_surface():
+    """The Protocol is the contract the polling loop depends on; assert
+    it exposes refresh and get_status. ParallelPerIdStatusProvider is the
+    concrete implementation."""
+    assert hasattr(StatusProvider, 'refresh')
+    assert hasattr(StatusProvider, 'get_status')
+
+
+def test_parallel_per_id_status_provider_returns_unknown_before_first_refresh():
+    """Before refresh has ever been called, every id reads as 'UNKNOWN' —
+    the loop's elif chain falls through, no transition that cycle."""
+    with ParallelPerIdStatusProvider(concurrency=2, refresh_timeout_seconds=10) as provider:
+        assert provider.get_status('any-id') == 'UNKNOWN'

--- a/tests/test_manage_dragen_mlr.py
+++ b/tests/test_manage_dragen_mlr.py
@@ -1,0 +1,96 @@
+"""Tests for the MLR submission helper.
+
+Focus: the AR-GUID-stamping branch added in PR 2. The popgen-cli
+invocation itself is shelled out and not exercised here — the helpers
+that touch ICA / the filesystem / subprocess are stubbed so the focus
+stays on the post-submit tag write and the per-SG state-file contract.
+"""
+
+import json
+
+import pytest
+
+from dragen_align_pa.jobs import manage_dragen_mlr
+
+
+def _write_state(tmp_path, **overrides):
+    state = {
+        'schema_version': 1,
+        'pipeline_id': 'dragen-id',
+        'user_reference': 'COH0001-batch0000',
+        'ar_guid': 'AR-GUID-12345',
+        'batch_index': 0,
+    }
+    state.update(overrides)
+    path = tmp_path / 'pid.json'
+    path.write_text(json.dumps(state))
+    return path
+
+
+def _stub_submission_helpers(monkeypatch):
+    """Stub everything _submit_mlr_run shells out to, leaving the
+    state-file read and the tag-write under test."""
+    monkeypatch.setattr(manage_dragen_mlr.ica_cli_utils, 'authenticate_ica_cli', lambda: None)
+    monkeypatch.setattr(
+        manage_dragen_mlr, '_mlr_find_input_urls',
+        lambda *_a, **_k: ('ica://a/cram', 'ica://a/gvcf'),
+    )
+    monkeypatch.setattr(manage_dragen_mlr, '_mlr_enter_project', lambda _p: None)
+    monkeypatch.setattr(
+        manage_dragen_mlr, '_mlr_download_config', lambda *_a, **_k: 'local-mlr-config.json',
+    )
+    monkeypatch.setattr(
+        manage_dragen_mlr, '_mlr_build_popgen_cli_command', lambda *_a, **_k: ['popgen', 'submit'],
+    )
+    monkeypatch.setattr(manage_dragen_mlr.utils, 'run_subprocess_with_log', lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        manage_dragen_mlr, '_mlr_parse_submission_output', lambda *_a, **_k: 'mlr-analysis-id',
+    )
+
+
+def _call_submit(state_path):
+    return manage_dragen_mlr._submit_mlr_run(
+        pipeline_id_arguid_path=state_path,
+        ica_analysis_output_folder='out',
+        sg_name='CPG_A',
+        cohort_name='COH0001',
+        mlr_project='mlr-project-name',
+        mlr_project_id='mlr-project-uuid',
+        mlr_config_json='cfg-id',
+        mlr_hash_table='ht-id',
+        output_prefix='ica://x',
+    )
+
+
+def test_submit_mlr_run_stamps_ar_guid_with_project_id(tmp_path, monkeypatch):
+    """The post-submit tag write must use the MLR *project id* (the UUID
+    update_analysis needs), the returned analysis id, and the raw AR-GUID
+    from the per-SG state file."""
+    _stub_submission_helpers(monkeypatch)
+    state_path = _write_state(tmp_path)
+
+    calls: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        'dragen_align_pa.ica_api_utils.add_technical_tag',
+        lambda project_id, analysis_id, tag: calls.append((project_id, analysis_id, tag)),
+    )
+
+    result = _call_submit(state_path)
+
+    assert result == 'mlr-analysis-id'
+    assert calls == [('mlr-project-uuid', 'mlr-analysis-id', 'AR-GUID-12345')]
+
+
+def test_submit_mlr_run_requires_ar_guid_in_state(tmp_path, monkeypatch):
+    """ar_guid is now a required key, so a state file missing it fails fast
+    at load time rather than as a KeyError mid-submission."""
+    _stub_submission_helpers(monkeypatch)
+    state_path = tmp_path / 'pid.json'
+    state_path.write_text(json.dumps({
+        'schema_version': 1,
+        'pipeline_id': 'dragen-id',
+        'user_reference': 'COH0001-batch0000',
+    }))
+
+    with pytest.raises(KeyError, match='ar_guid'):
+        _call_submit(state_path)

--- a/tests/test_submit_dragen_batch.py
+++ b/tests/test_submit_dragen_batch.py
@@ -1,5 +1,6 @@
 import json
 from contextlib import contextmanager
+from typing import Any
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -539,7 +540,7 @@ def test_run_includes_ar_guid_in_technical_tags(tmp_path, monkeypatch):
     )
 
     # Capture the body passed to submit_nextflow_analysis.
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     def fake_submit(**kwargs):
         captured['body'] = kwargs['body']

--- a/tests/test_submit_dragen_batch.py
+++ b/tests/test_submit_dragen_batch.py
@@ -1,3 +1,5 @@
+import json
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -496,3 +498,87 @@ def test_build_fastq_data_inputs_handles_duplicate_fastq_rows(tmp_path, monkeypa
     # Most-recent-wins: NEW IDs preserved, OLD discarded.
     assert sorted(ica_ids) == ['fil.NEW_R1', 'fil.NEW_R2']
     assert len(set(ica_ids)) == len(ica_ids), 'duplicate ICA IDs leaked into dataIds'
+
+
+def test_run_includes_ar_guid_in_technical_tags(tmp_path, monkeypatch):
+    """The AR-GUID must be appended to technicalTags at submit time so
+    operators can filter the ICA UI by cohort run, and so a future
+    bulk-list polling strategy can scope its query by tag."""
+    # Write a minimal analysis_output_fid_path JSON file.
+    analysis_output_fid_path = tmp_path / 'output_fid.json'
+    analysis_output_fid_path.write_text(json.dumps({'analysis_output_fid': 'fol.output123'}))
+
+    # Write a minimal CRAM state file for CPG_A.
+    cram_state_path = tmp_path / 'CPG_A_cram.json'
+    cram_state_path.write_text(json.dumps({
+        'schema_version': 1,
+        'sg_name': 'CPG_A',
+        'cram_fid': 'fil.cramfile',
+        'cram_index_fid': 'fil.craifile',
+        'ar_guid': 'AR-GUID-TEST',
+    }))
+
+    cfg = {
+        ('ica', 'tags', 'technical_tags'): ['existing-tag'],
+        ('ica', 'tags', 'user_tags'): ['user-tag'],
+        ('ica', 'tags', 'reference_tags'): ['ref-tag'],
+        ('dragen_align_pa', 'manage_dragen_pipeline', 'pipeline_id'): 'pipe-id-000',
+    }
+    monkeypatch.setattr(
+        submit_dragen_batch, 'config_retrieve',
+        lambda key, default=None: cfg.get(tuple(key), default),
+    )
+
+    # Stub try_get_ar_guid to return a known AR-GUID.
+    monkeypatch.setattr(submit_dragen_batch, 'try_get_ar_guid', lambda: 'AR-GUID-TEST')
+
+    # Stub secrets / project ID.
+    monkeypatch.setattr(
+        submit_dragen_batch.ica_api_utils, 'get_ica_secrets',
+        lambda: {'projectID': 'proj-test', 'apiKey': 'key-test'},
+    )
+
+    # Capture the body passed to submit_nextflow_analysis.
+    captured: dict[str, object] = {}
+
+    def fake_submit(**kwargs):
+        captured['body'] = kwargs['body']
+        return 'analysis-captured-id'
+
+    monkeypatch.setattr(submit_dragen_batch.ica_api_utils, 'submit_nextflow_analysis', fake_submit)
+
+    # Stub internal data-input and parameter builders to avoid full config wiring.
+    monkeypatch.setattr(submit_dragen_batch, '_build_common_data_inputs', list)
+    monkeypatch.setattr(
+        submit_dragen_batch, '_build_cram_data_inputs',
+        lambda batch, per_sg_state_paths: ([], ['fil.cramfile']),
+    )
+    monkeypatch.setattr(
+        submit_dragen_batch, '_build_top_level_parameters',
+        lambda error_strategy: [],
+    )
+
+    # Stub get_ica_api_client as a context manager returning a MagicMock.
+    @contextmanager
+    def fake_api_client():
+        yield MagicMock()
+
+    monkeypatch.setattr(submit_dragen_batch.ica_api_utils, 'get_ica_api_client', fake_api_client)
+
+    batch = IcaBatch(cohort_name='COH0001', batch_index=0, sg_names=['CPG_A'])
+    submit_dragen_batch.run(
+        batch=batch,
+        analysis_output_fid_path=analysis_output_fid_path,
+        cram_state_paths={'CPG_A': cram_state_path},
+        fastq_ids_path=None,
+        per_sg_fastq_list_paths=None,
+    )
+
+    body = captured['body']
+    # icasdk models are DynamicSchema (frozendict-based); access via dict keys.
+    technical_tags = list(body['tags']['technicalTags'])
+    assert 'AR-GUID-TEST' in technical_tags, (
+        f'AR-GUID not found in technicalTags: {technical_tags!r}'
+    )
+    # Original config tags must still be present.
+    assert 'existing-tag' in technical_tags

--- a/tests/test_submit_dragen_batch.py
+++ b/tests/test_submit_dragen_batch.py
@@ -78,11 +78,22 @@ def test_build_additional_args_includes_hardcoded_common(monkeypatch):
         '--vc-gvcf-gq-bands 10 20 30 40',
         '--vc-emit-ref-confidence GVCF',
         '--vc-enable-vcf-output false',
-        '--enable-map-align-output true',
-        '--enable-duplicate-marking true',
         '--repeat-genotype-enable true',
     ):
         assert required_flag in result, f'Missing required hardcoded flag: {required_flag!r}'
+
+
+def test_build_additional_args_omits_flags_the_pipeline_already_emits(monkeypatch):
+    """Regression: the DRAGEN pipeline XML emits --enable-map-align-output and
+    --enable-duplicate-marking automatically whenever enable_map_align=true (a
+    top-level param we always set). Repeating them in additional_args makes
+    DRAGEN see each flag twice and hard-error ('specified multiple times'),
+    failing the batch and triggering a retry batch that fails identically.
+    They must NOT appear in additional_args."""
+    monkeypatch.setattr(submit_dragen_batch, 'config_retrieve', _config_factory())
+    result = submit_dragen_batch._build_additional_args()
+    assert '--enable-map-align-output' not in result
+    assert '--enable-duplicate-marking' not in result
 
 
 def test_build_additional_args_cyp2d6_default_on(monkeypatch):


### PR DESCRIPTION
## Summary

Currently ICA pipeline runs are checked with a simple, sequenctial `for loop` for each sequencing group in the cohort. In large cohorts, this takes longer than the polling interval (10 minutes).

Replace this with a batched, parallel polling mechanism.

## Changes

- `jobs/ica_status_provider.py` (new): `StatusProvider` Protocol + `ParallelPerIdStatusProvider` — per-provider executor, `wait(timeout=...)` per-cycle cap, DEBUG/WARNING/ERROR log policy, `__enter__`/`__exit__`/`close`.
- `jobs/ica_pipeline_manager.py`: accept a `status_provider`, refresh once per cycle, route `pipeline_status` through `get_status`; own a default provider's lifetime in try/finally.
- `jobs/manage_dragen_pipeline.py` / `manage_dragen_mlr.py`: construct a project-aware provider in a `with` block and pass it in.
- `jobs/manage_dragen_mlr.py`: widen `load_per_sg_state` required_keys to include `ar_guid` (fail-fast); stamp the AR-GUID post-submit via `add_technical_tag`, threading the MLR project *id* (not the project name) as a parameter.
- `jobs/submit_dragen_batch.py` / `run_align_genotype_with_dragen.py`: append the AR-GUID to `technicalTags` at submit time.
- `ica_api_utils.py`: set `connection_pool_maxsize` from `[ica.polling] concurrency` so the fan-out isn't throttled by urllib3's default pool of 4; new `add_technical_tag(project_id, analysis_id, tag)` helper.
- `add_technical_tag` correctness fix: the helper must PUT the *complete* analysis object. `update_analysis` validates its body against the `Analysis` schema (ten required fields) during local serialization, so the original tags-only dataclass body raised `TypeError` before any HTTP call and was swallowed — the tag was never written. Now round-trips the full GET body, mutating only `technicalTags`, with a single 412 (ETag drift) retry.
- `config/dragen_align_pa_defaults.toml` + `tests/conftest.py`: new `[ica.polling]` section (`concurrency`, `refresh_timeout_seconds`) mirrored into the test config.
- Tests: new `test_ica_status_provider.py`, new `test_manage_dragen_mlr.py`, plus `test_ica_api_utils.py` / `test_ica_pipeline_manager.py` additions. The `add_technical_tag` suite includes a regression guard that runs the helper's body through the real icasdk request-body serializer — the check that would have caught the no-op.

## Test plan

- [x] `pytest -q` (184 passed)
- [x] `ruff@0.15.0 check src/dragen_align_pa tests`
- [x] `mypy@1.19.1 src/dragen_align_pa` (with `types-requests`, as the pre-commit hook installs)
- [ ] Small cohort end-to-end on `dragen-unified-dev`: confirm clean cycles emit no `n_failed` summary, an injected 429 is absorbed without tearing down the job, and the AR-GUID lands in `technicalTags` on both DRAGEN and MLR analyses.