### PR TITLE
Retry check_ica_pipeline_status on transient ICA 429/503

### DIFF
--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -63,6 +63,14 @@ reference_tags = ['test_reference_tags']
 [ica.api]
 batch_size = 30
 
+# Transient-error retry for ICA status polling (check_ica_pipeline_status).
+# max_retries = retries AFTER the initial attempt, so total tries = max_retries + 1.
+# Read at call time, so this can be tuned per-run without rebuilding the image.
+# NB: worst-case backoff is ~32s per retry at the cap, so a large value can
+# exceed a tight polling cycle.
+[ica.retry]
+max_retries = 10
+
 # The pipeline ID is from ICA and is specific to the exact pipeline being run. This should not need to be changed.
 [ica.pipelines]
 dragen_version = 'dragen_3_7_8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies=[
     'cpg-flow>=v1.0.1',
     'loguru',
     'pandas',
+    'tenacity',
 ]
 
 [project.urls]
@@ -118,6 +119,16 @@ ignore = [
 
 [tool.ruff.lint.isort]
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+
+[tool.ruff.lint.per-file-ignores]
+# Test code is held to a looser standard than production:
+# - SLF001: tests legitimately reach into private helpers/attributes.
+# - PLR2004: tests compare against literal "magic" values (counts, HTTP
+#   status codes, indices) where extracting a named constant adds no clarity.
+# - ANN202/ANN003: full return/kwargs annotations on test helpers/fixtures
+#   are noise.
+# - ARG005: unused lambda args in stubs are intentional.
+"tests/**" = ["SLF001", "PLR2004", "ANN202", "ANN003", "ARG005"]
 
 [tool.bumpversion]
 current_version = "3.5.2"

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -11,12 +11,20 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import icasdk
+from cpg_utils.config import config_retrieve
 from google.cloud import secretmanager
 from icasdk import ApiClient, Configuration
 from icasdk.apis.tags import project_analysis_api, project_data_api
 from icasdk.exceptions import ApiException
 from icasdk.model.create_nextflow_analysis import CreateNextflowAnalysis
 from loguru import logger
+from tenacity import (
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_fixed,
+    wait_random_exponential,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -28,6 +36,10 @@ ICA_REST_ENDPOINT: Final = 'https://ica.illumina.com/ica/rest'
 SECRET_PROJECT: Final = 'cpg-common'
 SECRET_NAME: Final = 'illumina_cpg_workbench_api'
 SECRET_VERSION: Final = 'latest'
+
+# Default retries (after the initial attempt) for transient ICA 429/503 on
+# check_ica_pipeline_status. Override per-run via [ica.retry] max_retries.
+_DEFAULT_ICA_MAX_RETRIES: Final = 10
 
 
 # --- Secret Management & Auth ---
@@ -83,11 +95,56 @@ def get_ica_api_client() -> Iterator[ApiClient]:
 # --- API Wrappers ---
 
 
+def _is_retryable_ica_error(exc: BaseException) -> bool:
+    """Tenacity predicate: retry only on transient ICA-side errors.
+
+    `icasdk.exceptions.ApiException` is a single class with `.status: int`,
+    so we cannot use `retry_if_exception_type` with a subclass. We check
+    `.status` directly. 429 = rate-limit (well-known production failure
+    mode); 503 = ICA backend unavailable. 404/500/etc propagate immediately
+    — retrying a permanent error just delays the real signal.
+    """
+    return isinstance(exc, ApiException) and exc.status in (429, 503)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def _ica_status_retrying() -> Retrying:
+    """Build the tenacity controller for check_ica_pipeline_status.
+
+    Read at call time (not at import) so the retry count can be tuned via
+    `[ica.retry] max_retries` in config without rebuilding the image, and to
+    avoid an import-time config_retrieve (config is not loaded when this module
+    is first imported).
+
+    `max_retries` is retries *after* the initial attempt, so total attempts is
+    `max_retries + 1`. Defaults to 10 retries.
+    """
+    max_retries = int(
+        config_retrieve(['ica', 'retry', 'max_retries'], default=_DEFAULT_ICA_MAX_RETRIES),
+    )
+    return Retrying(
+        retry=retry_if_exception(_is_retryable_ica_error),
+        stop=stop_after_attempt(max_retries + 1),
+        # wait_random_exponential gives a fully-randomised exponential backoff
+        # (each wait is random in [0, min(2^attempt, max)]), which desynchronises
+        # concurrent retries against a shared rate limit. The additive
+        # wait_fixed(2) is a hard 2s floor: wait_random_exponential can otherwise
+        # pick a near-zero first wait, letting a worker hammer ICA instantly
+        # after a 429. NB: worst-case backoff scales with max_retries (~32s per
+        # retry at the cap), so a large max_retries can exceed a tight polling
+        # cycle — tune both together.
+        wait=wait_random_exponential(multiplier=1, min=2, max=30) + wait_fixed(2),
+        reraise=True,
+    )
+
+
 def check_ica_pipeline_status(
     api_instance: project_analysis_api.ProjectAnalysisApi,
     path_params: dict[str, str],
 ) -> str:
-    """Check the status of an ICA pipeline via a pipeline ID
+    """Check the status of an ICA pipeline via a pipeline ID.
+
+    Transient ICA 429/503 errors are retried with jittered exponential backoff
+    (see `_ica_status_retrying`); other errors propagate on the first occurrence.
 
     Args:
         api_instance (project_analysis_api.ProjectAnalysisApi): An instance of the ProjectAnalysisApi
@@ -99,14 +156,20 @@ def check_ica_pipeline_status(
     Returns:
         str: The status of the pipeline. Can be one of ['REQUESTED', 'AWAITINGINPUT', 'INPROGRESS', 'SUCCEEDED', 'FAILED', 'FAILEDFINAL', 'ABORTED']
     """  # noqa: E501
-    try:
-        api_response = api_instance.get_analysis(path_params=path_params)  # type: ignore[ReportUnknownVariableType]
-        pipeline_status: str = api_response.body['status']  # type: ignore[ReportUnknownVariableType]
-        return pipeline_status  # type: ignore[ReportUnknownVariableType]
-    except icasdk.ApiException as e:
-        raise icasdk.ApiException(
-            f'Exception when calling ProjectAnalysisApi -> get_analysis: {e}',
-        ) from e
+
+    def _get_status() -> str:
+        try:
+            api_response = api_instance.get_analysis(path_params=path_params)  # type: ignore[ReportUnknownVariableType]
+            pipeline_status: str = api_response.body['status']  # type: ignore[ReportUnknownVariableType]
+            return pipeline_status  # type: ignore[ReportUnknownVariableType]
+        except icasdk.ApiException as e:
+            logger.error(
+                f'ProjectAnalysisApi.get_analysis raised for path_params={path_params}: '
+                f'status={e.status} reason={e.reason}',
+            )
+            raise
+
+    return _ica_status_retrying()(_get_status)
 
 
 def check_object_already_exists(
@@ -167,9 +230,11 @@ def check_object_already_exists(
         # Statuses are ["PARTIAL", "AVAILABLE", "ARCHIVING", "ARCHIVED", "UNARCHIVING", "DELETING", ]
         raise NotImplementedError(f'Checking for file status "{status}" is not implemented yet.')
     except icasdk.ApiException as e:
-        raise icasdk.ApiException(
-            f'Exception when calling ProjectDataApi -> get_project_data_list: {e}',
-        ) from e
+        logger.error(
+            f'ProjectDataApi.get_project_data_list raised for path_params={path_params}, '
+            f'file_name={file_name!r}: status={e.status} reason={e.reason}',
+        )
+        raise
 
 
 def find_file_id_by_name(
@@ -284,6 +349,8 @@ def submit_nextflow_analysis(
         analysis_id: str = api_response.body['id']  # type: ignore[ReportUnknownVariableType]
         return analysis_id
     except icasdk.ApiException as e:
-        raise icasdk.ApiException(
-            f'Exception when calling ProjectAnalysisApi->create_nextflow_analysis: {e}',
-        ) from e
+        logger.error(
+            f'ProjectAnalysisApi.create_nextflow_analysis raised for path_params={path_params}: '
+            f'status={e.status} reason={e.reason}',
+        )
+        raise

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -1,0 +1,163 @@
+"""Tests for ica_api_utils ICA-call resilience.
+
+Production tore down the monitor jobs when a single transient ICA 429
+(rate limit) propagated unhandled out of `check_ica_pipeline_status`.
+The fix retries transient 429/503 with jittered exponential backoff and
+stops re-wrapping `ApiException` (which clobbered `.status`, making any
+retry predicate dead code).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dragen_align_pa import ica_api_utils
+from icasdk.exceptions import ApiException
+
+
+@pytest.fixture(autouse=True)
+def _instant_retry_sleeps(monkeypatch):
+    """Tenacity sleeps between retries — patch time.sleep so the retry tests
+    don't take real wall-clock time. The retry logic is verified by call
+    counts and final outcomes, not by wait timings."""
+    monkeypatch.setattr('tenacity.nap.time.sleep', lambda _seconds: None)
+
+
+def _mock_api_with_status(status: int) -> object:
+    """Build a stand-in for ProjectAnalysisApi whose get_analysis raises an
+    ApiException with the given HTTP status preserved on the exception."""
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=status, reason='Too Many Requests')
+    return api
+
+
+def test_check_ica_pipeline_status_preserves_api_exception_status():
+    """Regression: the wrapper's old `raise ApiException(f'...{e}') from e`
+    pattern clobbered `.status` (the f-string went into the `status=`
+    positional, making it a str). Without `.status` preserved as int, any
+    downstream retry predicate `e.status in (429, 503)` is dead code.
+    The wrapper must propagate the original ApiException intact."""
+    api = _mock_api_with_status(429)
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.check_ica_pipeline_status(
+            api_instance=api,
+            path_params={'projectId': 'p', 'analysisId': 'a'},
+        )
+
+    assert exc_info.value.status == 429, (
+        f'expected .status == 429 to survive the wrapper; got {exc_info.value.status!r}'
+    )
+
+
+def test_submit_nextflow_analysis_preserves_api_exception_status():
+    """Same defect as test_check_ica_pipeline_status_preserves_api_exception_status,
+    different call site. submit_nextflow_analysis is the natural next target for
+    the retry decorator; ensure .status survives so the predicate can match."""
+    api = MagicMock()
+    api.create_nextflow_analysis.side_effect = ApiException(status=503, reason='Service Unavailable')
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.submit_nextflow_analysis(
+            api_instance=api,
+            path_params={'projectId': 'p'},
+            body=MagicMock(),
+        )
+
+    assert exc_info.value.status == 503
+
+
+def test_check_ica_pipeline_status_retries_on_429_then_succeeds():
+    """A transient 429 must be retried; the second attempt's success
+    populates the return value. Without this, a single ICA blip tears
+    down the cohort monitor (the originating production symptom)."""
+    api = MagicMock()
+    succeeding_response = MagicMock()
+    succeeding_response.body = {'status': 'INPROGRESS'}
+    api.get_analysis.side_effect = [
+        ApiException(status=429, reason='Too Many Requests'),
+        succeeding_response,
+    ]
+
+    result = ica_api_utils.check_ica_pipeline_status(
+        api_instance=api,
+        path_params={'projectId': 'p', 'analysisId': 'a'},
+    )
+
+    assert result == 'INPROGRESS'
+    assert api.get_analysis.call_count == 2
+
+
+def test_check_ica_pipeline_status_retries_on_503_then_succeeds():
+    """503 (ICA backend unavailable) is the other transient class the
+    retry must absorb."""
+    api = MagicMock()
+    succeeding_response = MagicMock()
+    succeeding_response.body = {'status': 'SUCCEEDED'}
+    api.get_analysis.side_effect = [
+        ApiException(status=503, reason='Service Unavailable'),
+        succeeding_response,
+    ]
+
+    result = ica_api_utils.check_ica_pipeline_status(
+        api_instance=api,
+        path_params={'projectId': 'p', 'analysisId': 'a'},
+    )
+
+    assert result == 'SUCCEEDED'
+    assert api.get_analysis.call_count == 2
+
+
+def test_check_ica_pipeline_status_does_not_retry_non_transient_status():
+    """A 404 (analysis not found) is a real not-retryable error — retrying
+    just delays the failure signal. Other non-(429|503) ApiExceptions must
+    propagate on the first occurrence."""
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=404, reason='Not Found')
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.check_ica_pipeline_status(
+            api_instance=api,
+            path_params={'projectId': 'p', 'analysisId': 'a'},
+        )
+
+    assert exc_info.value.status == 404
+    assert api.get_analysis.call_count == 1
+
+
+def test_check_ica_pipeline_status_gives_up_after_persistent_429():
+    """If every attempt 429s, eventually we surface the original
+    ApiException to the caller rather than retrying forever."""
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=429, reason='Too Many Requests')
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.check_ica_pipeline_status(
+            api_instance=api,
+            path_params={'projectId': 'p', 'analysisId': 'a'},
+        )
+
+    assert exc_info.value.status == 429
+    # Default 10 retries => 11 total attempts (initial + 10).
+    assert api.get_analysis.call_count == 11
+
+
+def test_check_ica_pipeline_status_retry_count_is_configurable(monkeypatch):
+    """[ica.retry] max_retries tunes the attempt count at call time, so it can
+    be changed via config without rebuilding the image. max_retries=2 => the
+    initial attempt + 2 retries = 3 total."""
+    monkeypatch.setattr(
+        ica_api_utils,
+        'config_retrieve',
+        lambda key, default=None: 2 if key == ['ica', 'retry', 'max_retries'] else default,
+    )
+    api = MagicMock()
+    api.get_analysis.side_effect = ApiException(status=429, reason='Too Many Requests')
+
+    with pytest.raises(ApiException):
+        ica_api_utils.check_ica_pipeline_status(
+            api_instance=api,
+            path_params={'projectId': 'p', 'analysisId': 'a'},
+        )
+
+    assert api.get_analysis.call_count == 3


### PR DESCRIPTION
## Summary

I need to add the same backoff and retry settings from dev into main, as downloading the non CRAM / gvcf files from ICA is causing more ICA API timeouts.

## Changes

- `src/dragen_align_pa/ica_api_utils.py`: add `_is_retryable_ica_error` predicate; build a call-time `Retrying` (`_ica_status_retrying`) driven by `[ica.retry] max_retries` (default 10) with `wait_random_exponential(min=2, max=30) + wait_fixed(2)`; stop the `.status`-clobbering re-wrap in all three wrappers (`check_ica_pipeline_status`, `check_object_already_exists`, `submit_nextflow_analysis`) — log context, re-raise the original exception.
- `config/dragen_align_pa_defaults.toml`: document the new `[ica.retry] max_retries` knob.
- `pyproject.toml`: add `tenacity` as an explicit dependency (was only transitive); add a `tests/**` ruff per-file-ignore set (PLR2004/ANN202/…) so test code lints clean.
- `tests/test_ica_api_utils.py` (new): `.status` survives the wrapper; 429/503 retry-then-succeed; 404 no-retry; persistent-429 gives up after 11 attempts (10 retries); retry count is configurable. An autouse fixture stubs tenacity's sleep so retry tests don't wait.

## Test plan

- [x] `pytest -q` (16 passed)
- [x] `ruff@0.15.0 check src/dragen_align_pa tests`
- [x] `mypy@1.19.1 src/dragen_align_pa` (with `types-requests`, as the pre-commit hook installs)
- [ ] Confirm on a real run that an injected/observed ICA 429 is absorbed without tearing down the monitor, and that `[ica.retry] max_retries` in the run TOML changes the attempt count.

## Notes

`max_retries` is retries *after* the initial attempt (total tries = `max_retries + 1`). Worst-case backoff is ~32s per retry at the cap, so a large value can exceed a tight polling cycle — tune with that in mind.