### PR TITLE
Apply ICA 429/503 retry to all data-plane calls

### DIFF
--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -7,8 +7,8 @@ wrappers around specific API endpoints.
 import contextlib
 import functools
 import json
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Final, Literal
+from collections.abc import Callable, Iterator
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar
 
 import icasdk
 from cpg_utils.config import config_retrieve
@@ -19,6 +19,7 @@ from icasdk.exceptions import ApiException
 from icasdk.model.create_nextflow_analysis import CreateNextflowAnalysis
 from loguru import logger
 from tenacity import (
+    RetryCallState,
     Retrying,
     retry_if_exception,
     stop_after_attempt,
@@ -29,6 +30,8 @@ from tenacity import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+_T = TypeVar('_T')
+
 
 # --- Constants ---
 
@@ -37,8 +40,8 @@ SECRET_PROJECT: Final = 'cpg-common'
 SECRET_NAME: Final = 'illumina_cpg_workbench_api'
 SECRET_VERSION: Final = 'latest'
 
-# Default retries (after the initial attempt) for transient ICA 429/503 on
-# check_ica_pipeline_status. Override per-run via [ica.retry] max_retries.
+# Default retries (after the initial attempt) for transient ICA 429/503 on any
+# data-plane call. Override per-run via [ica.retry] max_retries.
 _DEFAULT_ICA_MAX_RETRIES: Final = 10
 
 
@@ -107,8 +110,25 @@ def _is_retryable_ica_error(exc: BaseException) -> bool:
     return isinstance(exc, ApiException) and exc.status in (429, 503)  # pyright: ignore[reportAttributeAccessIssue]
 
 
-def _ica_status_retrying() -> Retrying:
-    """Build the tenacity controller for check_ica_pipeline_status.
+def _log_ica_retry(retry_state: RetryCallState) -> None:
+    """tenacity ``before_sleep`` hook: surface every transient-error retry.
+
+    Without this, a retried 429/503 is silent — making the retry machinery
+    "appear to do nothing" in the logs even when it is working. Fires only when
+    a retry is actually scheduled (i.e. on a retryable error with attempts left).
+    """
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    status = getattr(exc, 'status', '?')
+    fn_name = getattr(retry_state.fn, '__name__', repr(retry_state.fn))
+    sleep = retry_state.next_action.sleep if retry_state.next_action else 0.0
+    logger.warning(
+        f'ICA {fn_name} returned {status}; retrying '
+        f'(attempt {retry_state.attempt_number}) after {sleep:.1f}s',
+    )
+
+
+def _ica_retrying() -> Retrying:
+    """Build the shared tenacity controller for transient ICA 429/503 errors.
 
     Read at call time (not at import) so the retry count can be tuned via
     `[ica.retry] max_retries` in config without rebuilding the image, and to
@@ -133,8 +153,25 @@ def _ica_status_retrying() -> Retrying:
         # retry at the cap), so a large max_retries can exceed a tight polling
         # cycle — tune both together.
         wait=wait_random_exponential(multiplier=1, min=2, max=30) + wait_fixed(2),
+        before_sleep=_log_ica_retry,
         reraise=True,
     )
+
+
+def ica_retry(fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
+    """Invoke a single ICA SDK call with transient-429/503 retry.
+
+    Wraps `fn(*args, **kwargs)` in the shared jittered-backoff controller (see
+    `_ica_retrying`). Only 429 (rate limit) and 503 (backend unavailable) are
+    retried; every other error propagates on the first occurrence. The
+    controller is rebuilt per call so `[ica.retry] max_retries` is read from
+    config at call time.
+
+    Wrap only the SDK call itself, inside any existing try/except, so the
+    caller's error logging still fires on the *final* failure while
+    `_log_ica_retry` reports each intermediate retry.
+    """
+    return _ica_retrying()(fn, *args, **kwargs)
 
 
 def check_ica_pipeline_status(
@@ -144,7 +181,7 @@ def check_ica_pipeline_status(
     """Check the status of an ICA pipeline via a pipeline ID.
 
     Transient ICA 429/503 errors are retried with jittered exponential backoff
-    (see `_ica_status_retrying`); other errors propagate on the first occurrence.
+    (see `ica_retry`); other errors propagate on the first occurrence.
 
     Args:
         api_instance (project_analysis_api.ProjectAnalysisApi): An instance of the ProjectAnalysisApi
@@ -156,20 +193,16 @@ def check_ica_pipeline_status(
     Returns:
         str: The status of the pipeline. Can be one of ['REQUESTED', 'AWAITINGINPUT', 'INPROGRESS', 'SUCCEEDED', 'FAILED', 'FAILEDFINAL', 'ABORTED']
     """  # noqa: E501
-
-    def _get_status() -> str:
-        try:
-            api_response = api_instance.get_analysis(path_params=path_params)  # type: ignore[ReportUnknownVariableType]
-            pipeline_status: str = api_response.body['status']  # type: ignore[ReportUnknownVariableType]
-            return pipeline_status  # type: ignore[ReportUnknownVariableType]
-        except icasdk.ApiException as e:
-            logger.error(
-                f'ProjectAnalysisApi.get_analysis raised for path_params={path_params}: '
-                f'status={e.status} reason={e.reason}',
-            )
-            raise
-
-    return _ica_status_retrying()(_get_status)
+    try:
+        api_response = ica_retry(api_instance.get_analysis, path_params=path_params)  # type: ignore[ReportUnknownVariableType]
+        pipeline_status: str = api_response.body['status']  # type: ignore[ReportUnknownVariableType]
+        return pipeline_status  # type: ignore[ReportUnknownVariableType]
+    except icasdk.ApiException as e:
+        logger.error(
+            f'ProjectAnalysisApi.get_analysis raised for path_params={path_params}: '
+            f'status={e.status} reason={e.reason}',
+        )
+        raise
 
 
 def check_object_already_exists(
@@ -209,7 +242,8 @@ def check_object_already_exists(
         f'Checking to see if the {object_type} object already exists at {folder_path}/{file_name}',
     )
     try:
-        api_response = api_instance.get_project_data_list(  # type: ignore[ReportUnknownVariableType]
+        api_response = ica_retry(
+            api_instance.get_project_data_list,  # type: ignore[ReportUnknownVariableType]
             path_params=path_params,  # type: ignore[ReportUnknownVariableType]
             query_params=query_params,  # type: ignore[ReportUnknownVariableType]
         )  # type: ignore[ReportUnknownVariableType]
@@ -249,7 +283,8 @@ def find_file_id_by_name(
     """
     logger.info(f"Searching for file '{file_name}' in '{parent_folder_path}'...")
     try:
-        api_response = api_instance.get_project_data_list(  # pyright: ignore[reportUnknownVariableType]
+        api_response = ica_retry(
+            api_instance.get_project_data_list,  # pyright: ignore[reportUnknownVariableType]
             path_params=path_parameters,
             query_params={  # pyright: ignore[reportUnknownVariableType]
                 'parentFolderPath': parent_folder_path,
@@ -302,7 +337,8 @@ def get_file_details_from_ica(
             'pageSize': '2',
         }
 
-        api_response = api_instance.get_project_data_list(
+        api_response = ica_retry(
+            api_instance.get_project_data_list,
             path_params=path_params,
             query_params=query_params,
         )
@@ -341,7 +377,8 @@ def submit_nextflow_analysis(
     if header_params is None:
         header_params = {}
     try:
-        api_response = api_instance.create_nextflow_analysis(  # type: ignore[ReportUnknownVariableType]
+        api_response = ica_retry(
+            api_instance.create_nextflow_analysis,  # type: ignore[ReportUnknownVariableType]
             path_params=path_params,
             header_params=header_params,
             body=body,

--- a/src/dragen_align_pa/ica_utils.py
+++ b/src/dragen_align_pa/ica_utils.py
@@ -75,7 +75,8 @@ def create_upload_object_id(
                 folderPath=f'{folder_path}/',
                 dataType=object_type,
             )
-        api_response = api_instance.create_data_in_project(  # type: ignore[ReportUnknownVariableType]
+        api_response = ica_api_utils.ica_retry(
+            api_instance.create_data_in_project,  # type: ignore[ReportUnknownVariableType]
             path_params=path_params,  # type: ignore[ReportUnknownVariableType]
             body=body,
         )
@@ -100,7 +101,8 @@ def get_md5_from_ica(
     Returns (expected_hash, file_content).
     """
     try:
-        url_response = api_instance.create_download_url_for_data(  # pyright: ignore[reportUnknownVariableType]
+        url_response = ica_api_utils.ica_retry(
+            api_instance.create_download_url_for_data,  # pyright: ignore[reportUnknownVariableType]
             path_params=path_parameters | {'dataId': md5_file_id},
         )
         download_url = url_response.body['url']  # pyright: ignore[reportUnknownVariableType]
@@ -149,7 +151,8 @@ def stream_ica_file_to_gcs(
 
     try:
         # 1. Get pre-signed URL
-        url_response = api_instance.create_download_url_for_data(  # pyright: ignore[reportUnknownVariableType]
+        url_response = ica_api_utils.ica_retry(
+            api_instance.create_download_url_for_data,  # pyright: ignore[reportUnknownVariableType]
             path_params=path_parameters | {'dataId': file_id},  # pyright: ignore[reportArgumentType]
         )
         download_url = url_response.body['url']  # pyright: ignore[reportUnknownVariableType]
@@ -229,7 +232,8 @@ def list_and_filter_ica_files(
             query_params['pageToken'] = page_token
 
         try:
-            api_response = api_instance.get_project_data_list(  # pyright: ignore[reportUnknownVariableType]
+            api_response = ica_api_utils.ica_retry(
+                api_instance.get_project_data_list,  # pyright: ignore[reportUnknownVariableType]
                 path_params=path_parameters,  # pyright: ignore[reportArgumentType]
                 query_params=query_params,  # type: ignore[reportArgumentType]
             )

--- a/src/dragen_align_pa/jobs/download_md5_results.py
+++ b/src/dragen_align_pa/jobs/download_md5_results.py
@@ -42,7 +42,8 @@ def run(
 
         logger.info(f'Finding MD5 results for pipeline {pipeline_id}...')
 
-        api_response = api_instance.get_project_data_list(  # pyright: ignore[reportUnknownVariableType]
+        api_response = ica_api_utils.ica_retry(
+            api_instance.get_project_data_list,  # pyright: ignore[reportUnknownVariableType]
             path_params=path_parameters,  # pyright: ignore[reportArgumentType]
             query_params={
                 'filename': ['all_md5.txt'],
@@ -58,7 +59,8 @@ def run(
         logger.info(f'Found MD5 results file ID: {md5sum_results_id}')
 
         # Get a pre-signed URL
-        url_api_response = api_instance.create_download_url_for_data(  # pyright: ignore[reportUnknownVariableType]
+        url_api_response = ica_api_utils.ica_retry(
+            api_instance.create_download_url_for_data,  # pyright: ignore[reportUnknownVariableType]
             path_params=path_parameters | {'dataId': md5sum_results_id},  # pyright: ignore[reportArgumentType]
         )  # type: ignore  # noqa: PGH003
 

--- a/tests/test_ica_api_utils.py
+++ b/tests/test_ica_api_utils.py
@@ -161,3 +161,77 @@ def test_check_ica_pipeline_status_retry_count_is_configurable(monkeypatch):
         )
 
     assert api.get_analysis.call_count == 3
+
+
+# --- ica_retry helper: the shared controller all data-plane calls go through ---
+
+
+def test_ica_retry_retries_transient_then_returns():
+    """The public helper retries a 429 and returns the eventual success value,
+    so any data-plane SDK call wrapped in it survives a transient blip."""
+    call = MagicMock(side_effect=[ApiException(status=429, reason='Too Many Requests'), 'ok'])
+
+    result = ica_api_utils.ica_retry(call, path_params={'projectId': 'p'})
+
+    assert result == 'ok'
+    assert call.call_count == 2
+    # kwargs must be forwarded to the wrapped call on every attempt.
+    assert call.call_args_list[0].kwargs == {'path_params': {'projectId': 'p'}}
+
+
+def test_ica_retry_does_not_retry_non_transient():
+    """A 404 is a real, permanent error — surface it on the first attempt."""
+    call = MagicMock(side_effect=ApiException(status=404, reason='Not Found'))
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_api_utils.ica_retry(call)
+
+    assert exc_info.value.status == 404
+    assert call.call_count == 1
+
+
+# --- The other data-plane call sites now go through the retry ---
+
+
+def test_submit_nextflow_analysis_retries_on_429_then_succeeds():
+    """Pipeline submission is a data-plane POST; a 429 means the request was
+    rejected (not processed), so retrying is safe and must not tear down the run."""
+    api = MagicMock()
+    succeeding_response = MagicMock()
+    succeeding_response.body = {'id': 'ana.123'}
+    api.create_nextflow_analysis.side_effect = [
+        ApiException(status=429, reason='Too Many Requests'),
+        succeeding_response,
+    ]
+
+    analysis_id = ica_api_utils.submit_nextflow_analysis(
+        api_instance=api,
+        path_params={'projectId': 'p'},
+        body=MagicMock(),
+    )
+
+    assert analysis_id == 'ana.123'
+    assert api.create_nextflow_analysis.call_count == 2
+
+
+def test_check_object_already_exists_retries_on_503_then_succeeds():
+    """The existence check is the most-called data-plane endpoint
+    (get_project_data_list); it must absorb transient 503s."""
+    api = MagicMock()
+    succeeding_response = MagicMock()
+    succeeding_response.body = {'items': []}
+    api.get_project_data_list.side_effect = [
+        ApiException(status=503, reason='Service Unavailable'),
+        succeeding_response,
+    ]
+
+    result = ica_api_utils.check_object_already_exists(
+        api_instance=api,
+        path_params={'projectId': 'p'},
+        file_name='SYN1.cram',
+        folder_path='/bucket/folder',
+        object_type='FILE',
+    )
+
+    assert result is None
+    assert api.get_project_data_list.call_count == 2

--- a/tests/test_ica_utils.py
+++ b/tests/test_ica_utils.py
@@ -1,0 +1,83 @@
+"""Tests for ica_utils data-plane resilience.
+
+The originating production symptom (PR follow-up): a transient ICA 429 on
+`create_download_url_for_data` inside `stream_ica_file_to_gcs` propagated
+unhandled and killed the download job, even though tenacity retries had been
+added — because the retry was only wired into `check_ica_pipeline_status`,
+never into the download path. These tests pin the download-URL calls to the
+shared retry.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dragen_align_pa import ica_utils
+from icasdk.exceptions import ApiException
+
+
+@pytest.fixture(autouse=True)
+def _instant_retry_sleeps(monkeypatch):
+    """Patch tenacity's sleep so retry tests don't burn real wall-clock time."""
+    monkeypatch.setattr('tenacity.nap.time.sleep', lambda _seconds: None)
+
+
+def _streaming_response() -> MagicMock:
+    """A requests.get(...) stand-in usable as a context manager that yields one
+    chunk of content."""
+    resp = MagicMock()
+    resp.__enter__.return_value = resp
+    resp.iter_content.return_value = [b'chunk']
+    return resp
+
+
+def test_stream_ica_file_to_gcs_retries_download_url_on_429(monkeypatch):
+    """A 429 on create_download_url_for_data (the exact production traceback)
+    must be retried, not propagated; the second attempt's URL is then streamed."""
+    monkeypatch.setattr(ica_utils.requests, 'get', MagicMock(return_value=_streaming_response()))
+
+    api = MagicMock()
+    url_response = MagicMock()
+    url_response.body = {'url': 'https://signed.example/download'}
+    api.create_download_url_for_data.side_effect = [
+        ApiException(status=429, reason='Too Many Requests'),
+        url_response,
+    ]
+
+    ica_utils.stream_ica_file_to_gcs(
+        api_instance=api,
+        path_parameters={'projectId': 'p'},
+        file_id='fil.abc',
+        file_name='sample.qc.csv',
+        gcs_bucket=MagicMock(),
+        gcs_prefix='ica/output',
+    )
+
+    assert api.create_download_url_for_data.call_count == 2
+
+
+def test_stream_ica_file_to_gcs_gives_up_after_persistent_429(monkeypatch):
+    """Persistent 429 eventually surfaces the original ApiException to the caller."""
+    monkeypatch.setattr(
+        ica_utils.ica_api_utils,
+        'config_retrieve',
+        lambda key, default=None: 2 if key == ['ica', 'retry', 'max_retries'] else default,
+    )
+    monkeypatch.setattr(ica_utils.requests, 'get', MagicMock(return_value=_streaming_response()))
+
+    api = MagicMock()
+    api.create_download_url_for_data.side_effect = ApiException(status=429, reason='Too Many Requests')
+
+    with pytest.raises(ApiException) as exc_info:
+        ica_utils.stream_ica_file_to_gcs(
+            api_instance=api,
+            path_parameters={'projectId': 'p'},
+            file_id='fil.abc',
+            file_name='sample.qc.csv',
+            gcs_bucket=MagicMock(),
+            gcs_prefix='ica/output',
+        )
+
+    assert exc_info.value.status == 429
+    # max_retries=2 => initial attempt + 2 retries = 3 total.
+    assert api.create_download_url_for_data.call_count == 3


### PR DESCRIPTION
## Summary

The tenacity retry added in 762f842 was invoked at a single call site (`check_ica_pipeline_status` → `get_analysis`), and I forgot to wire it in for all the other API calls, especially the ones where it matters most (like downloading bulk data). This meant that all the download calls had no retires.

## Changes

- `src/dragen_align_pa/ica_api_utils.py`: rename `_ica_status_retrying` → `_ica_retrying` (the backoff is generic, not status-specific); add a public `ica_retry(fn, *args, **kwargs)` helper that wraps one SDK call in the controller; add a `before_sleep` hook so each retry is logged; route `get_analysis`, `get_project_data_list` (×3), and `create_nextflow_analysis` through it.

- `src/dragen_align_pa/ica_utils.py`: route `create_data_in_project`, both `create_download_url_for_data` calls (incl. the one in the production traceback), and `get_project_data_list` through `ica_retry`.

- `src/dragen_align_pa/jobs/download_md5_results.py`: route `get_project_data_list` and `create_download_url_for_data` through `ica_retry`.

- `tests/test_ica_api_utils.py`: add coverage for the `ica_retry` helper (retries transient, not 404) and for retry on `submit_nextflow_analysis` and `check_object_already_exists`.

- `tests/test_ica_utils.py`: new file pinning the originally-failing path — `stream_ica_file_to_gcs` retries a 429 on the download-URL call and gives up after persistent 429s.

## Test plan

- [x] `pytest tests/` (22 passed)
- [x] `ruff check` (v0.15.0, pinned) — clean
- [x] `pre-commit run` (mypy v1.19.1, ruff, cpg-id-checker) — pass