### PR TITLE
Allow dragen cram input

### DIFF
--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -84,6 +84,10 @@ md5_pipeline_id = "e767f290-bc60-4281-b11d-6a65c9791253"
 [ica.pipelines.md5]
 chunk_size = "100"
 
+# Allow upload of Dragen crams, as they are not referenced directly by sequencing_group.cram
+[dragen_align_pa.upload_data_to_ica]
+use_dragen_crams = false
+
 # Unified DRAGEN378 pipeline (single pipeline for CRAM/FASTQ, WGS/WES)
 [dragen_align_pa.manage_dragen_pipeline]
 pipeline_id = "aa2661f0-2d2f-4d84-989a-c435f35016d3"

--- a/src/dragen_align_pa/ica_utils.py
+++ b/src/dragen_align_pa/ica_utils.py
@@ -12,11 +12,11 @@ from typing import TYPE_CHECKING
 import cpg_utils
 import icasdk
 import requests
+import tenacity
 from google.cloud import exceptions as gcs_exceptions
 from icasdk.model.create_data import CreateData
 from icasdk.model.data_id_or_path_list import DataIdOrPathList
 from loguru import logger
-from tenacity import retry, retry_always, stop_after_attempt, wait_exponential
 
 from dragen_align_pa import ica_api_utils
 
@@ -389,10 +389,10 @@ def finalise_upload(
     )
 
 
-@retry(
-    retry=retry_always,  # ICA API exceptions are opaque and hard to pin down
-    stop=stop_after_attempt(4),
-    wait=wait_exponential(multiplier=1, min=1, max=10),
+@tenacity.retry(
+    retry=tenacity.retry_if_exception_type(FileNotFoundError),
+    stop=tenacity.stop_after_attempt(4),
+    wait=tenacity.wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,
 )
 def wait_for_file_available(

--- a/src/dragen_align_pa/jobs/upload_data_to_ica.py
+++ b/src/dragen_align_pa/jobs/upload_data_to_ica.py
@@ -27,8 +27,8 @@ def _setup_paths(
 ) -> dict[str, str]:
     """Resolve the GCS source, local scratch, and ICA destination paths for the upload.
 
-    In DRAGEN mode (``use_dragen_crams``) the source is the DRAGEN realignment
-    output CRAM; otherwise it is the sequencing group's own CRAM.
+    Allows for using Dragen generated CRAMs if the config setting
+    'dragen_align_pa.upload_data_to_ica.use_dragen_crams' is true.
 
     Args:
         sequencing_group: The sequencing group whose CRAM is being uploaded;
@@ -36,12 +36,12 @@ def _setup_paths(
         upload_folder: ICA folder name under which the CRAM is staged.
 
     Returns:
-        A dict with keys ``sg_name``, ``cram_name``, ``gcs_cram_path``,
-        ``local_cram_path``, and ``ica_folder_path``.
+        A dict with keys 'sg_name', 'cram_name', 'gcs_cram_path',
+        'local_cram_path', and 'ica_folder_path'.
 
     Raises:
-        ValueError: In non-DRAGEN mode, if ``sequencing_group.cram.path`` is
-            neither a ``.cram`` nor a ``.cram.crai`` path.
+        ValueError: In non-DRAGEN mode, if 'sequencing_group.cram.path' is
+            neither a '.cram' nor a '.cram.crai' path.
     """
     sg_name: str = sequencing_group.name
     cram_name = f'{sg_name}.cram'

--- a/src/dragen_align_pa/jobs/upload_data_to_ica.py
+++ b/src/dragen_align_pa/jobs/upload_data_to_ica.py
@@ -11,12 +11,13 @@ Uses a hybrid PythonJob approach:
 import os
 from typing import Literal
 
+import cpg_utils.config
 from cpg_flow.targets import SequencingGroup
 from icasdk.apis.tags import project_data_api
 from loguru import logger
 
 from dragen_align_pa import ica_api_utils, ica_cli_utils, ica_utils
-from dragen_align_pa.constants import BUCKET_NAME
+from dragen_align_pa.constants import BUCKET_NAME, DRAGEN_VERSION
 from dragen_align_pa.utils import validate_cli_path_input
 
 
@@ -30,16 +31,26 @@ def _setup_paths(
     sg_name: str = sequencing_group.name
     cram_name = f'{sg_name}.cram'
 
-    # Ensure we get the .cram path, not .crai
-    gcs_base_path = str(sequencing_group.cram)
-    if gcs_base_path.endswith('.cram.crai'):
-        gcs_cram_path = gcs_base_path.removesuffix('.crai')
-    elif not gcs_base_path.endswith('.cram'):
-        raise ValueError(
-            f'Unexpected path for sequencing_group.cram: {gcs_base_path}',
+    if cpg_utils.config.config_retrieve(['dragen_align_pa', 'upload_data_to_ica', 'use_dragen_crams'], False):
+        gcs_cram_path: cpg_utils.Path | str = (
+            sequencing_group.dataset.prefix()
+            / 'ica'
+            / DRAGEN_VERSION
+            / 'output'
+            / 'cram'
+            / f'{sequencing_group.name}.cram'
         )
     else:
-        gcs_cram_path = gcs_base_path
+        # Ensure we get the .cram path, not .crai
+        gcs_base_path: str = str(sequencing_group.cram.path)
+        if gcs_base_path.endswith('.cram.crai'):
+            gcs_cram_path = gcs_base_path.removesuffix('.crai')
+        elif not gcs_base_path.endswith('.cram'):
+            raise ValueError(
+                f'Unexpected path for sequencing_group.cram: {gcs_base_path}',
+            )
+        else:
+            gcs_cram_path = gcs_base_path
 
     logger.info(f'Resolved CRAM path to upload: {gcs_cram_path}')
 
@@ -49,7 +60,7 @@ def _setup_paths(
     return {
         'sg_name': sg_name,
         'cram_name': cram_name,
-        'gcs_cram_path': gcs_cram_path,
+        'gcs_cram_path': str(gcs_cram_path),
         'local_cram_path': local_cram_path,
         'ica_folder_path': f'/{BUCKET_NAME}/{upload_folder}/{sg_name}/',
     }

--- a/src/dragen_align_pa/jobs/upload_data_to_ica.py
+++ b/src/dragen_align_pa/jobs/upload_data_to_ica.py
@@ -25,8 +25,23 @@ def _setup_paths(
     sequencing_group: SequencingGroup,
     upload_folder: str,
 ) -> dict[str, str]:
-    """
-    Resolves and returns all necessary paths and names for the job.
+    """Resolve the GCS source, local scratch, and ICA destination paths for the upload.
+
+    In DRAGEN mode (``use_dragen_crams``) the source is the DRAGEN realignment
+    output CRAM; otherwise it is the sequencing group's own CRAM.
+
+    Args:
+        sequencing_group: The sequencing group whose CRAM is being uploaded;
+            supplies the SG name and, in non-DRAGEN mode, the source CRAM path.
+        upload_folder: ICA folder name under which the CRAM is staged.
+
+    Returns:
+        A dict with keys ``sg_name``, ``cram_name``, ``gcs_cram_path``,
+        ``local_cram_path``, and ``ica_folder_path``.
+
+    Raises:
+        ValueError: In non-DRAGEN mode, if ``sequencing_group.cram.path`` is
+            neither a ``.cram`` nor a ``.cram.crai`` path.
     """
     sg_name: str = sequencing_group.name
     cram_name = f'{sg_name}.cram'


### PR DESCRIPTION
# Purpose

  - Dragen CRAMs are stored at `<bucket>/ica/...`, which is NOT the path that sequencing_group.cram` resolves to. If we need to rerun Dragen using a Dragen generated CRAM file, this change enables that.

## Proposed Changes

  - Config setting to switch between CRAMs that are produced by Dragen and live under `<bucket>/ica/...` and others that live under the `sequencing_group.cram` path.
  - Update the docstring for the `_setup_paths` function to comply to the new styleguide.
  - Fix the `wait_for_file_available` function to work correctly on `FileNotFound`, not always.

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
