### PR TITLE
Lower default batching setting and add explanation

### DIFF
--- a/config/dragen_align_pa_defaults.toml
+++ b/config/dragen_align_pa_defaults.toml
@@ -63,7 +63,10 @@ user_tags = ['test_user_tags']
 reference_tags = ['test_reference_tags']
 
 [ica.api]
-batch_size = 30
+# How many fastq samples to query ICA for in a batch.
+# Filenames get base64 encoded when returned by the ICA API, and the API has a hard limit of 2000 characters in the
+# response. For AGRF delivered fastq files, 15 samples per batch is the maximum.
+batch_size = 15
 
 # Bulk output download: how many pre-signed URLs to mint per :createDownloadUrls
 # call. Larger batches make fewer (rate-limited) API calls but hold URLs longer


### PR DESCRIPTION
# Purpose

  - Lower the default setting of `batch_size` for the md5 pipeline to avoid a preventable runtime error

## Proposed Changes

  - Change the default setting from 30 -> 15