### PR TITLE
Cast lanes to str, as the format in the manifest changed

### DIFF
--- a/src/dragen_align_pa/jobs/make_fastq_file_list.py
+++ b/src/dragen_align_pa/jobs/make_fastq_file_list.py
@@ -81,7 +81,14 @@ def _write_fastq_list_file(fq_df: pd.DataFrame, outputs: dict[str, cpg_utils.Pat
 
 def run(outputs: dict[str, cpg_utils.Path], cohort: Cohort, manifest_file_path: cpg_utils.Path) -> None:
     with cpg_utils.to_path(manifest_file_path).open() as manifest_fh:
-        supplied_manifest_data: pd.DataFrame = pd.read_csv(manifest_fh)
+        supplied_manifest_data: pd.DataFrame = pd.read_csv(
+            manifest_fh,
+            dtype={
+                config_retrieve(['manifest', 'lane']): str,
+                config_retrieve(['manifest', 'machine_id']): str,
+                config_retrieve(['manifest', 'flowcell']): str,
+            },
+        )
 
     for sequencing_group in cohort.get_sequencing_groups():
         fq_df: pd.DataFrame = supplied_manifest_data[


### PR DESCRIPTION
# Purpose

  - The manifest file parser changed the data in the lane column from Lane01 -> 1, thus breaking the pipeline. This fix casts the lane column to a `str` when reading in the manifest.

## Proposed Changes

  - Cast lane to `str`, along with other manifest columns that could break the pipeline.