### PR TITLE
Normalise ICA path construction

### DIFF
--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -154,8 +154,7 @@ def _log_ica_retry(retry_state: RetryCallState) -> None:
     fn_name = getattr(retry_state.fn, '__name__', repr(retry_state.fn))
     sleep = retry_state.next_action.sleep if retry_state.next_action else 0.0
     logger.warning(
-        f'ICA {fn_name} returned {status}; retrying '
-        f'(attempt {retry_state.attempt_number}) after {sleep:.1f}s',
+        f'ICA {fn_name} returned {status}; retrying (attempt {retry_state.attempt_number}) after {sleep:.1f}s',
     )
 
 
@@ -262,7 +261,7 @@ def check_object_already_exists(
         tuple[str, str] | None: (object_ID, object_status) if it exists, or else None
     """
     query_params: dict[str, Sequence[str] | list[str] | str] = {
-        'filePath': [f'{folder_path}/{file_name}'],
+        'filePath': [f'/{folder_path.strip("/")}/{file_name}'],
         'filePathMatchMode': 'STARTS_WITH_CASE_INSENSITIVE',
         'type': object_type,
     }
@@ -316,7 +315,7 @@ def find_file_id_by_name(
             api_instance.get_project_data_list,  # pyright: ignore[reportUnknownVariableType]
             path_params=path_parameters,
             query_params={  # pyright: ignore[reportUnknownVariableType]
-                'parentFolderPath': parent_folder_path,
+                'parentFolderPath': '/' + parent_folder_path.strip('/') + '/',
                 'filename': [file_name],
                 'filenameMatchMode': 'EXACT',
                 'pageSize': '2',
@@ -359,7 +358,7 @@ def get_file_details_from_ica(
     """
     try:
         query_params: dict[str, Any] = {
-            'parentFolderPath': ica_folder_path,
+            'parentFolderPath': '/' + ica_folder_path.strip('/') + '/',
             'filename': [file_name],
             'filenameMatchMode': 'EXACT',
             'pageSize': '2',

--- a/src/dragen_align_pa/ica_api_utils.py
+++ b/src/dragen_align_pa/ica_api_utils.py
@@ -310,12 +310,13 @@ def find_file_id_by_name(
     Finds a specific file ID in an ICA folder by its exact name.
     (Used by download_specific_files_from_ica.py)
     """
+    ica_normalised_folder_path: str = '/' + parent_folder_path.strip('/') + '/'
     try:
         api_response = ica_retry(
             api_instance.get_project_data_list,  # pyright: ignore[reportUnknownVariableType]
             path_params=path_parameters,
             query_params={  # pyright: ignore[reportUnknownVariableType]
-                'parentFolderPath': '/' + parent_folder_path.strip('/') + '/',
+                'parentFolderPath': ica_normalised_folder_path,
                 'filename': [file_name],
                 'filenameMatchMode': 'EXACT',
                 'pageSize': '2',
@@ -325,7 +326,7 @@ def find_file_id_by_name(
         items = api_response.body.get('items', [])  # pyright: ignore[reportUnknownVariableType]
         if not items:  # pyright: ignore[reportUnknownArgumentType]
             raise FileNotFoundError(
-                f'File not found in ICA: {parent_folder_path}{file_name}',
+                f'File not found in ICA: {ica_normalised_folder_path}{file_name}',
             )
         if len(items) > 1:  # pyright: ignore[reportUnknownArgumentType]
             logger.warning(

--- a/src/dragen_align_pa/ica_utils.py
+++ b/src/dragen_align_pa/ica_utils.py
@@ -51,6 +51,11 @@ def create_upload_object_id(
         tuple[str, str]: (object_ID, status)
         Status will be from ICA, e.g. 'AVAILABLE', 'PARTIAL'.
     """
+    # Normalise to a single leading slash and no trailing slash; the existence
+    # check and CreateData below both append their own '/', so a caller passing
+    # a trailing slash would otherwise produce a double slash in the ICA path.
+    folder_path = '/' + folder_path.strip('/')
+
     existing_object_details: tuple[str, str] | None = ica_api_utils.check_object_already_exists(
         api_instance=api_instance,
         path_params=path_params,
@@ -277,7 +282,7 @@ def list_ica_files(
     have been collected, those collected entries are discarded and the
     ``icasdk.ApiException`` propagates. Callers should re-run on failure.
     """
-    base = base_ica_folder_path.rstrip('/') + '/'
+    base = '/' + base_ica_folder_path.strip('/') + '/'
 
     def _list_children(parent: str, type_: str) -> list[dict]:
         items: list[dict] = []

--- a/src/dragen_align_pa/ica_utils.py
+++ b/src/dragen_align_pa/ica_utils.py
@@ -54,7 +54,7 @@ def create_upload_object_id(
     # Normalise to a single leading slash and no trailing slash; the existence
     # check and CreateData below both append their own '/', so a caller passing
     # a trailing slash would otherwise produce a double slash in the ICA path.
-    folder_path = '/' + folder_path.strip('/')
+    folder_path = '/' + folder_path.strip('/') + '/'
 
     existing_object_details: tuple[str, str] | None = ica_api_utils.check_object_already_exists(
         api_instance=api_instance,
@@ -73,13 +73,13 @@ def create_upload_object_id(
         if object_type == 'FILE':
             body = CreateData(
                 name=file_name,
-                folderPath=f'{folder_path}/',
+                folderPath=folder_path,
                 dataType=object_type,
             )
         else:
             body = CreateData(
                 name=folder_name,
-                folderPath=f'{folder_path}/',
+                folderPath=folder_path,
                 dataType=object_type,
             )
         api_response = ica_api_utils.ica_retry(

--- a/src/dragen_align_pa/jobs/download_md5_results.py
+++ b/src/dragen_align_pa/jobs/download_md5_results.py
@@ -42,20 +42,15 @@ def run(
 
         logger.info(f'Finding MD5 results for pipeline {pipeline_id}...')
 
-        api_response = ica_api_utils.ica_retry(
-            api_instance.get_project_data_list,  # pyright: ignore[reportUnknownVariableType]
-            path_params=path_parameters,  # pyright: ignore[reportArgumentType]
-            query_params={
-                'filename': ['all_md5.txt'],
-                'filenameMatchMode': 'EXACT',
-                'parentFolderPath': f'{folder_path}/{cohort_name}/{cohort_name}_{ar_guid}-{pipeline_id}/',
-            },  # pyright: ignore[reportArgumentType]
-        )  # type: ignore  # noqa: PGH003
-
-        if not api_response.body['items']:  # pyright: ignore[reportUnknownVariableType]
-            raise FileNotFoundError(f'Could not find "all_md5.txt" in output folder for pipeline {pipeline_id}')
-
-        md5sum_results_id: str = api_response.body['items'][0]['data']['id']  # pyright: ignore[reportUnknownVariableType]
+        # Routes through find_file_id_by_name so the parentFolderPath slash
+        # normalisation lives in one place (raises FileNotFoundError if absent).
+        parent_folder_path = f'{folder_path}/{cohort_name}/{cohort_name}_{ar_guid}-{pipeline_id}/'
+        md5sum_results_id: str = ica_api_utils.find_file_id_by_name(
+            api_instance=api_instance,
+            path_parameters=path_parameters,
+            parent_folder_path=parent_folder_path,
+            file_name='all_md5.txt',
+        )
         logger.info(f'Found MD5 results file ID: {md5sum_results_id}')
 
         # Get a pre-signed URL

--- a/tests/test_ica_path_normalisation.py
+++ b/tests/test_ica_path_normalisation.py
@@ -1,0 +1,117 @@
+"""Tests that ICA folder/file paths are normalised to a single leading AND
+trailing slash before reaching the ICA API, regardless of how the caller
+slashes its input.
+
+ICA's `parentFolderPath`/`filePath` queries throws an API error when
+the slash convention is off, so this invariant is load-bearing. The helpers
+each normalise their own query, so a caller passing `foo/bar`, `/foo/bar`,
+`/foo/bar/`, or `//foo/bar//` must all produce the same canonical path. These
+tests capture the query_params handed to a MagicMock api_instance — no live
+ICA calls.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dragen_align_pa import ica_api_utils, ica_utils
+
+# Every variant must normalise to the same canonical `/foo/bar/`.
+_PARENT_VARIANTS = ['foo/bar', '/foo/bar', '/foo/bar/', '//foo/bar//', 'foo/bar/']
+
+
+def _capture_api(body: dict) -> tuple[MagicMock, list[dict]]:
+    """MagicMock api_instance that records each query_params and returns `body`."""
+    calls: list[dict] = []
+
+    def fake_list(path_params, query_params):  # noqa: ARG001
+        calls.append(query_params)
+        return MagicMock(body=body)
+
+    api = MagicMock()
+    api.get_project_data_list.side_effect = fake_list
+    return api, calls
+
+
+@pytest.mark.parametrize('parent', _PARENT_VARIANTS)
+def test_find_file_id_by_name_normalises_parent_folder_path(parent: str):
+    api, calls = _capture_api({'items': [{'data': {'id': 'fid_x'}}]})
+
+    result = ica_api_utils.find_file_id_by_name(
+        api_instance=api,
+        path_parameters={'projectId': 'p'},
+        parent_folder_path=parent,
+        file_name='all_md5.txt',
+    )
+
+    assert result == 'fid_x'
+    assert calls[0]['parentFolderPath'] == '/foo/bar/'
+
+
+@pytest.mark.parametrize('parent', _PARENT_VARIANTS)
+def test_get_file_details_from_ica_normalises_parent_folder_path(parent: str):
+    api, calls = _capture_api({'items': [{'data': {'id': 'fid_x', 'details': {'status': 'AVAILABLE'}}}]})
+
+    result = ica_api_utils.get_file_details_from_ica(
+        api_instance=api,
+        path_params={'projectId': 'p'},
+        ica_folder_path=parent,
+        file_name='sample.cram',
+    )
+
+    assert result is not None
+    assert calls[0]['parentFolderPath'] == '/foo/bar/'
+
+
+@pytest.mark.parametrize('parent', _PARENT_VARIANTS)
+def test_check_object_already_exists_normalises_file_path(parent: str):
+    api, calls = _capture_api({'items': [{'data': {'id': 'fid_x', 'details': {'status': 'AVAILABLE'}}}]})
+
+    ica_api_utils.check_object_already_exists(
+        api_instance=api,
+        path_params={'projectId': 'p'},
+        file_name='thing.csv',
+        folder_path=parent,
+        object_type='FILE',
+    )
+
+    assert calls[0]['filePath'] == ['/foo/bar/thing.csv']
+
+
+@pytest.mark.parametrize('parent', _PARENT_VARIANTS)
+def test_list_ica_files_normalises_leading_and_trailing_slash(parent: str):
+    api, calls = _capture_api({'items': [], 'nextPageToken': None})
+
+    ica_utils.list_ica_files(
+        api_instance=api,
+        path_parameters={'projectId': 'p'},
+        base_ica_folder_path=parent,
+    )
+
+    assert calls[0]['parentFolderPath'] == '/foo/bar/'
+
+
+@pytest.mark.parametrize('folder', _PARENT_VARIANTS)
+def test_create_upload_object_id_normalises_path_on_create(folder: str):
+    """When the object doesn't yet exist, both the existence-check `filePath`
+    and the `CreateData` `folderPath` carry a single leading+trailing slash."""
+    api, calls = _capture_api({'items': []})  # not found → proceeds to create
+    api.create_data_in_project.return_value = MagicMock(
+        body={'data': {'id': 'new_fid', 'details': {'status': 'AVAILABLE'}}},
+    )
+
+    file_id, status = ica_utils.create_upload_object_id(
+        api_instance=api,
+        path_params={'projectId': 'p'},
+        folder_name='myfolder',
+        file_name='thing.csv',
+        folder_path=folder,
+        object_type='FILE',
+    )
+
+    assert (file_id, status) == ('new_fid', 'AVAILABLE')
+    # Existence check reflects the normalised folder_path.
+    assert calls[0]['filePath'] == ['/foo/bar/thing.csv']
+    # CreateData body carries a single leading+trailing slash (no double slash).
+    body = api.create_data_in_project.call_args.kwargs['body']
+    assert body['folderPath'] == '/foo/bar/'


### PR DESCRIPTION
Normalise the ICA path construction to ensure leading and trailing forward slash in the parentPath

# Purpose

  - ICA paths in API requests strictly enforce starting and ending with `/` in the `parentPath` attribute. This was inconsistently applied over the codebase, and lead to issues (although not in test?)

## Proposed Changes

  - Normalise the `parentPath` in the helper functions, so that even if the code forgets to construct the path correctly, it is ok.
  -

## Checklist

- [x] Tests covering new change
- [ ] Linting checks pass
