### PR TITLE
Add back md5sum calculations for the reheadered MLR gvcfs

### DIFF
--- a/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
+++ b/src/dragen_align_pa/jobs/reheader_mlr_gvcf.py
@@ -41,6 +41,8 @@ def reheader_mlr_gvcf(
         reheadered_gvcf={
             'gvcf.gz': '{root}.gvcf.gz',
             'gvcf.gz.tbi': '{root}.gvcf.gz.tbi',
+            'gvcf.gz.md5sum': '{root}.gvcf.gz.md5sum',
+            'gvcf.gz.tbi.md5sum': '{root}.gvcf.gz.tbi.md5sum',
         }
     )
 
@@ -53,6 +55,9 @@ def reheader_mlr_gvcf(
         bcftools annotate --no-version --write-index=tbi \\
             -h <(bcftools view -h {gvcf_input_group['base_gvcf']} | grep '^##GVCFBlock') \\
             {gvcf_input_group['recal_gvcf']} -o {reheadered_gvcf_outputs['gvcf.gz']} -Oz
+
+        md5sum {reheadered_gvcf_outputs['gvcf.gz']} > {reheadered_gvcf_outputs['gvcf.gz.md5sum']}
+        md5sum {reheadered_gvcf_outputs['gvcf.gz.tbi']} > {reheadered_gvcf_outputs['gvcf.gz.tbi.md5sum']}
 
         """
     )

--- a/src/dragen_align_pa/stages.py
+++ b/src/dragen_align_pa/stages.py
@@ -680,6 +680,10 @@ class ReheaderMlrGvcf(SequencingGroupStage):
         return {
             'gvcf': get_output_path(filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz'),
             'gvcf_tbi': get_output_path(filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz.tbi'),
+            'gvcf_md5': get_output_path(filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz.md5'),
+            'gvcf_tbi_md5': get_output_path(
+                filename=f'recal_gvcf/{sequencing_group.name}.hard-filtered.recal.gvcf.gz.tbi.md5'
+            ),
         }
 
     def queue_jobs(self, sequencing_group: SequencingGroup, inputs: StageInput) -> StageOutput | None:


### PR DESCRIPTION
# Purpose

  - Reheadering the MLR gvcfs invalidated the ICA md5sums, and they also were not being copied over from `-tmp` (an oversight, but fortunate as they would not have matched). This change re-calculates the md5sum on the reheadered MLR gvcf and persists it to main storage.

## Proposed Changes

  - Add in md5sum calculation after reheadering.

## Checklist

- [x] Linting checks pass
- [x] Checks on `fewgenomes` pass
